### PR TITLE
Update go.mod and import paths for github.com/f5 prefix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/lquerel/otel-arrow-adapter
+module github.com/f5/otel-arrow-adapter
 
 go 1.18
 

--- a/pkg/air/arrow_util.go
+++ b/pkg/air/arrow_util.go
@@ -26,7 +26,7 @@ import (
 	"github.com/apache/arrow/go/v9/arrow/array"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/common"
+	"github.com/f5/otel-arrow-adapter/pkg/air/common"
 )
 
 type SortableField struct {

--- a/pkg/air/builder.go
+++ b/pkg/air/builder.go
@@ -25,11 +25,11 @@ import (
 	"github.com/apache/arrow/go/v9/arrow/ipc"
 	"github.com/apache/arrow/go/v9/arrow/memory"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/column"
-	config2 "github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/dictionary"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/stats"
+	"github.com/f5/otel-arrow-adapter/pkg/air/column"
+	config2 "github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/air/dictionary"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/stats"
 )
 
 type OrderBy struct {

--- a/pkg/air/column/binary.go
+++ b/pkg/air/column/binary.go
@@ -21,9 +21,9 @@ import (
 	"github.com/apache/arrow/go/v9/arrow/array"
 	"github.com/apache/arrow/go/v9/arrow/memory"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/stats"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/stats"
 )
 
 // BinaryColumn is a column of binary data.

--- a/pkg/air/column/bool.go
+++ b/pkg/air/column/bool.go
@@ -19,7 +19,7 @@ import (
 	"github.com/apache/arrow/go/v9/arrow/array"
 	"github.com/apache/arrow/go/v9/arrow/memory"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 // BoolColumn is a column of boolean data.

--- a/pkg/air/column/columns.go
+++ b/pkg/air/column/columns.go
@@ -21,10 +21,10 @@ import (
 	"github.com/apache/arrow/go/v9/arrow"
 	"github.com/apache/arrow/go/v9/arrow/memory"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/dictionary"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/stats"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/air/dictionary"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/stats"
 )
 
 // Column is a generic interface to interact with all types of column.

--- a/pkg/air/column/float.go
+++ b/pkg/air/column/float.go
@@ -19,7 +19,7 @@ import (
 	"github.com/apache/arrow/go/v9/arrow/array"
 	"github.com/apache/arrow/go/v9/arrow/memory"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 // F32Column is a column of float32 data.

--- a/pkg/air/column/int.go
+++ b/pkg/air/column/int.go
@@ -19,7 +19,7 @@ import (
 	"github.com/apache/arrow/go/v9/arrow/array"
 	"github.com/apache/arrow/go/v9/arrow/memory"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 // I8Column is a column of int8 data.

--- a/pkg/air/column/list.go
+++ b/pkg/air/column/list.go
@@ -22,9 +22,9 @@ import (
 	"github.com/apache/arrow/go/v9/arrow/bitutil"
 	"github.com/apache/arrow/go/v9/arrow/memory"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/dictionary"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/air/dictionary"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 type ListColumn interface {

--- a/pkg/air/column/string.go
+++ b/pkg/air/column/string.go
@@ -21,9 +21,9 @@ import (
 	"github.com/apache/arrow/go/v9/arrow/array"
 	"github.com/apache/arrow/go/v9/arrow/memory"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/stats"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/stats"
 )
 
 // StringColumn is a column of optional string values.

--- a/pkg/air/column/struct.go
+++ b/pkg/air/column/struct.go
@@ -21,8 +21,8 @@ import (
 	"github.com/apache/arrow/go/v9/arrow/array"
 	"github.com/apache/arrow/go/v9/arrow/memory"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/stats"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/stats"
 )
 
 type ArrowFields []*arrow.Field

--- a/pkg/air/column/uint.go
+++ b/pkg/air/column/uint.go
@@ -19,7 +19,7 @@ import (
 	"github.com/apache/arrow/go/v9/arrow/array"
 	"github.com/apache/arrow/go/v9/arrow/memory"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 // U8Column is a column of uint8 data.

--- a/pkg/air/config_test/config_test.go
+++ b/pkg/air/config_test/config_test.go
@@ -17,7 +17,7 @@ package config_test
 import (
 	"testing"
 
-	config2 "github.com/lquerel/otel-arrow-adapter/pkg/air/config"
+	config2 "github.com/f5/otel-arrow-adapter/pkg/air/config"
 )
 
 func TestIsDictionary(t *testing.T) {

--- a/pkg/air/record.go
+++ b/pkg/air/record.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/apache/arrow/go/v9/arrow"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 type Records struct {

--- a/pkg/air/repo.go
+++ b/pkg/air/repo.go
@@ -21,7 +21,7 @@ import (
 	"github.com/apache/arrow/go/v9/arrow"
 	"github.com/apache/arrow/go/v9/arrow/memory"
 
-	config2 "github.com/lquerel/otel-arrow-adapter/pkg/air/config"
+	config2 "github.com/f5/otel-arrow-adapter/pkg/air/config"
 )
 
 type RecordRepository struct {

--- a/pkg/air/rfield/data_type.go
+++ b/pkg/air/rfield/data_type.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/apache/arrow/go/v9/arrow"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/common"
+	"github.com/f5/otel-arrow-adapter/pkg/air/common"
 )
 
 type NameTypes []*NameType

--- a/pkg/air/rfield/value.go
+++ b/pkg/air/rfield/value.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/apache/arrow/go/v9/arrow"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/common"
+	"github.com/f5/otel-arrow-adapter/pkg/air/common"
 )
 
 type Value interface {

--- a/pkg/air/rfield_test/binary_value_test.go
+++ b/pkg/air/rfield_test/binary_value_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/apache/arrow/go/v9/arrow"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 func TestCoerceFromString(t *testing.T) {

--- a/pkg/air/rfield_test/bool_value_test.go
+++ b/pkg/air/rfield_test/bool_value_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/apache/arrow/go/v9/arrow"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 func TestCoerceFromBool(t *testing.T) {

--- a/pkg/air/rfield_test/data_type_test.go
+++ b/pkg/air/rfield_test/data_type_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/apache/arrow/go/v9/arrow"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 func TestWriteDataTypeSignature(t *testing.T) {

--- a/pkg/air/rfield_test/int_value_test.go
+++ b/pkg/air/rfield_test/int_value_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/apache/arrow/go/v9/arrow"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 func TestCoerceFromI8(t *testing.T) {

--- a/pkg/air/rfield_test/list_value_test.go
+++ b/pkg/air/rfield_test/list_value_test.go
@@ -20,7 +20,7 @@ package value
 import (
 	"testing"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 func TestListDataType(t *testing.T) {

--- a/pkg/air/rfield_test/string_value_test.go
+++ b/pkg/air/rfield_test/string_value_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/apache/arrow/go/v9/arrow"
 	"github.com/apache/arrow/go/v9/arrow/memory"
 
-	value2 "github.com/lquerel/otel-arrow-adapter/pkg/air/column"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
+	value2 "github.com/f5/otel-arrow-adapter/pkg/air/column"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
 )
 
 func TestStringColumn(t *testing.T) {

--- a/pkg/air/rfield_test/uint_value_test.go
+++ b/pkg/air/rfield_test/uint_value_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/apache/arrow/go/v9/arrow"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 func TestCoerceFromU8(t *testing.T) {

--- a/pkg/air/rfield_test/value_test.go
+++ b/pkg/air/rfield_test/value_test.go
@@ -17,7 +17,7 @@ package value_test
 import (
 	"testing"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 func TestNormalize(t *testing.T) {

--- a/pkg/air_test/record_gen_test.go
+++ b/pkg/air_test/record_gen_test.go
@@ -17,8 +17,8 @@ package air_test
 import (
 	"fmt"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 func GenSimpleRecord(ts int64) *air.Record {

--- a/pkg/air_test/record_test.go
+++ b/pkg/air_test/record_test.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 func TestValue(t *testing.T) {

--- a/pkg/air_test/repo_test.go
+++ b/pkg/air_test/repo_test.go
@@ -25,9 +25,9 @@ import (
 	"github.com/apache/arrow/go/v9/arrow/array"
 	"github.com/davecgh/go-spew/spew"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	config2 "github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	config2 "github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
 )
 
 func TestAddRecord(t *testing.T) {

--- a/pkg/benchmark/dataset/real_trace_dataset.go
+++ b/pkg/benchmark/dataset/real_trace_dataset.go
@@ -24,7 +24,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/common"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/common"
 
 	"golang.org/x/exp/rand"
 

--- a/pkg/benchmark/dataset/synthetic_dataset.go
+++ b/pkg/benchmark/dataset/synthetic_dataset.go
@@ -18,8 +18,8 @@
 package dataset
 
 import (
-	"github.com/lquerel/otel-arrow-adapter/pkg/datagen"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/common"
+	"github.com/f5/otel-arrow-adapter/pkg/datagen"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/common"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"

--- a/pkg/benchmark/profileable/otlp/logs.go
+++ b/pkg/benchmark/profileable/otlp/logs.go
@@ -3,8 +3,8 @@ package otlp
 import (
 	"io"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/dataset"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/dataset"
 
 	plog "go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"

--- a/pkg/benchmark/profileable/otlp/metrics.go
+++ b/pkg/benchmark/profileable/otlp/metrics.go
@@ -6,8 +6,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/dataset"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/dataset"
 )
 
 type MetricsProfileable struct {

--- a/pkg/benchmark/profileable/otlp/trace.go
+++ b/pkg/benchmark/profileable/otlp/trace.go
@@ -3,8 +3,8 @@ package otlp
 import (
 	"io"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/dataset"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/dataset"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"

--- a/pkg/benchmark/profileable/otlp_arrow/logs.go
+++ b/pkg/benchmark/profileable/otlp_arrow/logs.go
@@ -5,13 +5,13 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
-	v1 "github.com/lquerel/otel-arrow-adapter/api/collector/arrow/v1"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/dataset"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/arrow_record"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/logs"
+	v1 "github.com/f5/otel-arrow-adapter/api/collector/arrow/v1"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/dataset"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/arrow_record"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/logs"
 
 	"go.opentelemetry.io/collector/pdata/plog"
 )

--- a/pkg/benchmark/profileable/otlp_arrow/metrics.go
+++ b/pkg/benchmark/profileable/otlp_arrow/metrics.go
@@ -5,13 +5,13 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
-	v1 "github.com/lquerel/otel-arrow-adapter/api/collector/arrow/v1"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/dataset"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/arrow_record"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/metrics"
+	v1 "github.com/f5/otel-arrow-adapter/api/collector/arrow/v1"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/dataset"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/arrow_record"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/metrics"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )

--- a/pkg/benchmark/profileable/otlp_arrow/trace.go
+++ b/pkg/benchmark/profileable/otlp_arrow/trace.go
@@ -5,12 +5,12 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
-	v1 "github.com/lquerel/otel-arrow-adapter/api/collector/arrow/v1"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/dataset"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/arrow_record"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/traces"
+	v1 "github.com/f5/otel-arrow-adapter/api/collector/arrow/v1"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/dataset"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/arrow_record"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/traces"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )

--- a/pkg/benchmark_test/compression_test.go
+++ b/pkg/benchmark_test/compression_test.go
@@ -17,7 +17,7 @@ package benchmark
 import (
 	"testing"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark"
 )
 
 func TestLz4(t *testing.T) {

--- a/pkg/benchmark_test/otlp_arrow_profiler_test.go
+++ b/pkg/benchmark_test/otlp_arrow_profiler_test.go
@@ -17,11 +17,11 @@ package benchmark
 import (
 	"testing"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/dataset"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/profileable/otlp_arrow"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/metrics"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/dataset"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/profileable/otlp_arrow"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/metrics"
 )
 
 func TestOtlpArrowMetricsProfiler(t *testing.T) {

--- a/pkg/benchmark_test/otlp_profiler_test.go
+++ b/pkg/benchmark_test/otlp_profiler_test.go
@@ -17,9 +17,9 @@ package benchmark
 import (
 	"testing"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/dataset"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/profileable/otlp"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/dataset"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/profileable/otlp"
 )
 
 func TestOtlpMetricsProfiler(t *testing.T) {

--- a/pkg/benchmark_test/stats_test.go
+++ b/pkg/benchmark_test/stats_test.go
@@ -17,7 +17,7 @@ package benchmark_test
 import (
 	"testing"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark"
 )
 
 func TestSummary(t *testing.T) {

--- a/pkg/otel/arrow_record/arrow_record.go
+++ b/pkg/otel/arrow_record/arrow_record.go
@@ -15,13 +15,13 @@
  *
  */
 
-package arrow_record
+package arrow_record // import "github.com/f5/otel-arrow-adapter/pkg/otel/arrow_record"
 
 import (
 	"github.com/apache/arrow/go/v9/arrow"
 
-	v1 "github.com/lquerel/otel-arrow-adapter/api/collector/arrow/v1"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
+	v1 "github.com/f5/otel-arrow-adapter/api/collector/arrow/v1"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
 )
 
 type PayloadType = v1.OtlpArrowPayloadType

--- a/pkg/otel/arrow_record/consumer.go
+++ b/pkg/otel/arrow_record/consumer.go
@@ -23,8 +23,8 @@ import (
 	"github.com/apache/arrow/go/v9/arrow/ipc"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
-	colarspb "github.com/lquerel/otel-arrow-adapter/api/collector/arrow/v1"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/traces"
+	colarspb "github.com/f5/otel-arrow-adapter/api/collector/arrow/v1"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/traces"
 )
 
 // Consumer is a BatchArrowRecords consumer.

--- a/pkg/otel/arrow_record/producer.go
+++ b/pkg/otel/arrow_record/producer.go
@@ -21,9 +21,9 @@ import (
 	"github.com/apache/arrow/go/v9/arrow/ipc"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
-	colarspb "github.com/lquerel/otel-arrow-adapter/api/collector/arrow/v1"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/traces"
+	colarspb "github.com/f5/otel-arrow-adapter/api/collector/arrow/v1"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/traces"
 )
 
 // Producer is a BatchArrowRecords producer.

--- a/pkg/otel/batch_arrow_records_test/producer_consumer_test.go
+++ b/pkg/otel/batch_arrow_records_test/producer_consumer_test.go
@@ -21,11 +21,11 @@ import (
 	"fmt"
 	"testing"
 
-	v1 "github.com/lquerel/otel-arrow-adapter/api/collector/arrow/v1"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	cfg "github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/arrow_record"
+	v1 "github.com/f5/otel-arrow-adapter/api/collector/arrow/v1"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	cfg "github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/arrow_record"
 )
 
 func TestProducerConsumer(t *testing.T) {

--- a/pkg/otel/common/arrow_to_otlp.go
+++ b/pkg/otel/common/arrow_to_otlp.go
@@ -24,8 +24,8 @@ import (
 	"github.com/apache/arrow/go/v9/arrow"
 	"github.com/apache/arrow/go/v9/arrow/array"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )

--- a/pkg/otel/common/otlp_to_arrow.go
+++ b/pkg/otel/common/otlp_to_arrow.go
@@ -21,11 +21,11 @@ import (
 
 	"github.com/apache/arrow/go/v9/arrow"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/common"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	"github.com/f5/otel-arrow-adapter/pkg/air/common"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )

--- a/pkg/otel/logs/arrow_to_otlp.go
+++ b/pkg/otel/logs/arrow_to_otlp.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/apache/arrow/go/v9/arrow"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/common"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/common"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"

--- a/pkg/otel/logs/otlp_to_arrow.go
+++ b/pkg/otel/logs/otlp_to_arrow.go
@@ -17,10 +17,10 @@ package logs
 import (
 	"github.com/apache/arrow/go/v9/arrow"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/common"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/common"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
 
 	"go.opentelemetry.io/collector/pdata/plog"
 )

--- a/pkg/otel/logs_test/otlp_to_arrow_test.go
+++ b/pkg/otel/logs_test/otlp_to_arrow_test.go
@@ -17,10 +17,10 @@ package logs_test
 import (
 	"testing"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/datagen"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/logs"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/datagen"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/logs"
 )
 
 func TestOtlpLogsToArrowRecords(t *testing.T) {

--- a/pkg/otel/metrics/arrow_to_otlp.go
+++ b/pkg/otel/metrics/arrow_to_otlp.go
@@ -23,9 +23,9 @@ import (
 	"github.com/apache/arrow/go/v9/arrow"
 	"github.com/apache/arrow/go/v9/arrow/array"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/common"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/common"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"

--- a/pkg/otel/metrics/otlp_to_arrow.go
+++ b/pkg/otel/metrics/otlp_to_arrow.go
@@ -17,11 +17,11 @@ package metrics
 import (
 	"fmt"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/common"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/common"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"

--- a/pkg/otel/metrics_test/arrow_to_otlp_test.go
+++ b/pkg/otel/metrics_test/arrow_to_otlp_test.go
@@ -17,11 +17,11 @@ package metrics_test
 import (
 	"testing"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/datagen"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/metrics"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/oteltest"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/datagen"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/metrics"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/oteltest"
 )
 
 func TestSystemCpuTimeConversion(t *testing.T) {

--- a/pkg/otel/metrics_test/data_point_test.go
+++ b/pkg/otel/metrics_test/data_point_test.go
@@ -17,7 +17,7 @@ package metrics
 import (
 	"testing"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/metrics"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/metrics"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pmetric"

--- a/pkg/otel/metrics_test/otlp_to_arrow_test.go
+++ b/pkg/otel/metrics_test/otlp_to_arrow_test.go
@@ -17,10 +17,10 @@ package metrics_test
 import (
 	"testing"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/datagen"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/metrics"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/datagen"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/metrics"
 )
 
 func TestOtlpMetricsToArrowRecords(t *testing.T) {

--- a/pkg/otel/oteltest/oteltest.go
+++ b/pkg/otel/oteltest/oteltest.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"sort"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/metrics"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/metrics"
 
 	"github.com/google/go-cmp/cmp"
 	"go.opentelemetry.io/collector/pdata/pmetric"

--- a/pkg/otel/traces/otlp_arrow_producer.go
+++ b/pkg/otel/traces/otlp_arrow_producer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package traces
+package traces // import "github.com/f5/otel-arrow-adapter/pkg/otel/traces"
 
 import (
 	"io"
@@ -20,11 +20,11 @@ import (
 
 	"github.com/apache/arrow/go/v9/arrow"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/rfield"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/common"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/air/rfield"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/common"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )

--- a/pkg/otel/traces/otlp_producer.go
+++ b/pkg/otel/traces/otlp_producer.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/apache/arrow/go/v9/arrow"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/common"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/air"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/common"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"

--- a/pkg/otel/traces/traces_test.go
+++ b/pkg/otel/traces/traces_test.go
@@ -20,9 +20,9 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/dataset"
-	"github.com/lquerel/otel-arrow-adapter/pkg/datagen"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/assert"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/dataset"
+	"github.com/f5/otel-arrow-adapter/pkg/datagen"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/assert"
 )
 
 // TestConversionFromSyntheticData tests the conversion of OTLP traces to Arrow and back to OTLP.

--- a/pkg/otel_test/writer_test.go
+++ b/pkg/otel_test/writer_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/apache/arrow/go/v9/arrow/ipc"
 	"github.com/davecgh/go-spew/spew"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/datagen"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/traces"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/datagen"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/traces"
 )
 
 func TestIPCWriter(t *testing.T) {

--- a/tools/logs_benchmark/main.go
+++ b/tools/logs_benchmark/main.go
@@ -22,11 +22,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/dataset"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/profileable/otlp"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/profileable/otlp_arrow"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/dataset"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/profileable/otlp"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/profileable/otlp_arrow"
 )
 
 var help = flag.Bool("help", false, "Show help")

--- a/tools/logs_gen/main.go
+++ b/tools/logs_gen/main.go
@@ -25,7 +25,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/datagen"
+	"github.com/f5/otel-arrow-adapter/pkg/datagen"
 )
 
 var help = flag.Bool("help", false, "Show help")

--- a/tools/metrics_benchmark/main.go
+++ b/tools/metrics_benchmark/main.go
@@ -22,12 +22,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/dataset"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/profileable/otlp"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/profileable/otlp_arrow"
-	"github.com/lquerel/otel-arrow-adapter/pkg/otel/metrics"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/dataset"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/profileable/otlp"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/profileable/otlp_arrow"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/metrics"
 )
 
 var help = flag.Bool("help", false, "Show help")

--- a/tools/metrics_gen/main.go
+++ b/tools/metrics_gen/main.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/datagen"
+	"github.com/f5/otel-arrow-adapter/pkg/datagen"
 
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 )

--- a/tools/trace_benchmark/main.go
+++ b/tools/trace_benchmark/main.go
@@ -21,11 +21,11 @@ import (
 
 	"github.com/dustin/go-humanize"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/air/config"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/dataset"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/profileable/otlp"
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/profileable/otlp_arrow"
+	"github.com/f5/otel-arrow-adapter/pkg/air/config"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/dataset"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/profileable/otlp"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/profileable/otlp_arrow"
 )
 
 var help = flag.Bool("help", false, "Show help")

--- a/tools/trace_gen/main.go
+++ b/tools/trace_gen/main.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/datagen"
+	"github.com/f5/otel-arrow-adapter/pkg/datagen"
 
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 )

--- a/tools/trace_head/main.go
+++ b/tools/trace_head/main.go
@@ -22,7 +22,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 
-	"github.com/lquerel/otel-arrow-adapter/pkg/benchmark/dataset"
+	"github.com/f5/otel-arrow-adapter/pkg/benchmark/dataset"
 )
 
 var help = flag.Bool("help", false, "Show help")


### PR DESCRIPTION
Replaces `lquerel` with `f5`.