### PR TITLE
Add a traces producer/consumer fuzz test

### DIFF
--- a/pkg/benchmark/dataset/real_trace_dataset.go
+++ b/pkg/benchmark/dataset/real_trace_dataset.go
@@ -20,13 +20,12 @@ package dataset
 import (
 	"fmt"
 	"log"
+	"math/rand"
 	"os"
 	"sort"
 	"strings"
 
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/arrow"
-
-	"golang.org/x/exp/rand"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"

--- a/pkg/benchmark/dataset/synthetic_dataset.go
+++ b/pkg/benchmark/dataset/synthetic_dataset.go
@@ -18,6 +18,8 @@
 package dataset
 
 import (
+	"math/rand"
+
 	"github.com/f5/otel-arrow-adapter/pkg/datagen"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/arrow"
 
@@ -55,7 +57,8 @@ type FakeMetricsDataset struct {
 }
 
 func NewFakeMetricsDataset(len int) *FakeMetricsDataset {
-	return &FakeMetricsDataset{len: len, generator: datagen.NewMetricsGenerator(datagen.DefaultResourceAttributes(), datagen.DefaultInstrumentationScopes())}
+	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+	return &FakeMetricsDataset{len: len, generator: datagen.NewMetricsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())}
 }
 
 func (d *FakeMetricsDataset) Len() int {
@@ -75,7 +78,8 @@ type FakeLogsDataset struct {
 }
 
 func NewFakeLogsDataset(len int) *FakeLogsDataset {
-	return &FakeLogsDataset{len: len, generator: datagen.NewLogsGenerator(datagen.DefaultResourceAttributes(), datagen.DefaultInstrumentationScopes())}
+	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+	return &FakeLogsDataset{len: len, generator: datagen.NewLogsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())}
 }
 
 func (d *FakeLogsDataset) Len() int {
@@ -95,7 +99,8 @@ type FakeTraceDataset struct {
 }
 
 func NewFakeTraceDataset(len int) *FakeTraceDataset {
-	return &FakeTraceDataset{len: len, generator: datagen.NewTracesGenerator(datagen.DefaultResourceAttributes(), datagen.DefaultInstrumentationScopes())}
+	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+	return &FakeTraceDataset{len: len, generator: datagen.NewTracesGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())}
 }
 
 func (d *FakeTraceDataset) Len() int {

--- a/pkg/datagen/logs.go
+++ b/pkg/datagen/logs.go
@@ -29,9 +29,9 @@ type LogsGenerator struct {
 	generation int
 }
 
-func NewLogsGenerator(resourceAttributes []pcommon.Map, instrumentationScopes []pcommon.InstrumentationScope) *LogsGenerator {
+func NewLogsGenerator(entropy TestEntropy, resourceAttributes []pcommon.Map, instrumentationScopes []pcommon.InstrumentationScope) *LogsGenerator {
 	return &LogsGenerator{
-		DataGenerator: NewDataGenerator(uint64(time.Now().UnixNano()/int64(time.Millisecond)), resourceAttributes, instrumentationScopes),
+		DataGenerator: NewDataGenerator(entropy, resourceAttributes, instrumentationScopes),
 		generation:    0,
 	}
 }
@@ -85,7 +85,7 @@ func (dg *DataGenerator) logRecord(log plog.LogRecord, sev plog.SeverityNumber, 
 	log.SetSeverityNumber(sev)
 	log.SetSeverityText(txt)
 	log.Body().SetStr(gofakeit.LoremIpsumSentence(10))
-	DefaultAttributes().CopyTo(log.Attributes())
+	dg.NewStandardAttributes().CopyTo(log.Attributes())
 	log.SetTraceID(dg.Id16Bytes())
 	log.SetSpanID(dg.Id8Bytes())
 }

--- a/pkg/datagen/metrics.go
+++ b/pkg/datagen/metrics.go
@@ -28,9 +28,9 @@ type MetricsGenerator struct {
 	generation int
 }
 
-func NewMetricsGenerator(resourceAttributes []pcommon.Map, instrumentationScopes []pcommon.InstrumentationScope) *MetricsGenerator {
+func NewMetricsGenerator(entropy TestEntropy, resourceAttributes []pcommon.Map, instrumentationScopes []pcommon.InstrumentationScope) *MetricsGenerator {
 	return &MetricsGenerator{
-		DataGenerator: NewDataGenerator(uint64(time.Now().UnixNano()/int64(time.Millisecond)), resourceAttributes, instrumentationScopes),
+		DataGenerator: NewDataGenerator(entropy, resourceAttributes, instrumentationScopes),
 		generation:    0,
 	}
 }

--- a/pkg/otel/arrow_record/producer_consumer_test.go
+++ b/pkg/otel/arrow_record/producer_consumer_test.go
@@ -2,6 +2,7 @@ package arrow_record
 
 import (
 	"encoding/json"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -17,10 +18,13 @@ import (
 func FuzzProducerConsumerTraces(f *testing.F) {
 	const numSeeds = 5
 
+	ent := datagen.NewTestEntropy(12345)
+
 	for i := 0; i < numSeeds; i++ {
 		dg := datagen.NewTracesGenerator(
-			datagen.DefaultResourceAttributes(),
-			datagen.DefaultInstrumentationScopes(),
+			ent,
+			ent.NewStandardResourceAttributes(),
+			ent.NewStandardInstrumentationScopes(),
 		)
 		traces1 := dg.Generate(i+1, time.Minute)
 		traces2 := dg.Generate(i+1, time.Minute)
@@ -61,9 +65,12 @@ func FuzzProducerConsumerTraces(f *testing.F) {
 }
 
 func TestProducerConsumerTraces(t *testing.T) {
+	ent := datagen.NewTestEntropy(int64(rand.Uint64()))
+
 	dg := datagen.NewTracesGenerator(
-		datagen.DefaultResourceAttributes(),
-		datagen.DefaultInstrumentationScopes(),
+		ent,
+		ent.NewStandardResourceAttributes(),
+		ent.NewStandardInstrumentationScopes(),
 	)
 	traces := dg.Generate(10, time.Minute)
 
@@ -85,9 +92,12 @@ func TestProducerConsumerTraces(t *testing.T) {
 }
 
 func TestProducerConsumerLogs(t *testing.T) {
+	ent := datagen.NewTestEntropy(int64(rand.Uint64()))
+
 	dg := datagen.NewLogsGenerator(
-		datagen.DefaultResourceAttributes(),
-		datagen.DefaultInstrumentationScopes(),
+		ent,
+		ent.NewStandardResourceAttributes(),
+		ent.NewStandardInstrumentationScopes(),
 	)
 	logs := dg.Generate(10, time.Minute)
 

--- a/pkg/otel/logs/validation_test.go
+++ b/pkg/otel/logs/validation_test.go
@@ -16,6 +16,7 @@ package logs_test
 
 import (
 	"encoding/json"
+	"math/rand"
 	"testing"
 
 	"github.com/apache/arrow/go/v11/arrow/memory"
@@ -34,7 +35,8 @@ import (
 func TestConversionFromSyntheticData(t *testing.T) {
 	t.Parallel()
 
-	logsGen := datagen.NewLogsGenerator(datagen.DefaultResourceAttributes(), datagen.DefaultInstrumentationScopes())
+	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+	logsGen := datagen.NewLogsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 
 	// Generate a random OTLP logs request.
 	expectedRequest := plogotlp.NewExportRequestFromLogs(logsGen.Generate(10, 100))

--- a/pkg/otel/metrics/validation_test.go
+++ b/pkg/otel/metrics/validation_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"encoding/json"
+	"math/rand"
 	"testing"
 
 	"github.com/apache/arrow/go/v11/arrow/memory"
@@ -20,7 +21,9 @@ import (
 func TestConversionFromSyntheticData(t *testing.T) {
 	t.Parallel()
 
-	metricsGen := datagen.NewMetricsGenerator(datagen.DefaultResourceAttributes(), datagen.DefaultInstrumentationScopes())
+	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+
+	metricsGen := datagen.NewMetricsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 
 	// Generate a random OTLP metrics request.
 	expectedRequest := pmetricotlp.NewExportRequestFromMetrics(metricsGen.Generate(10, 100))

--- a/pkg/otel/metrics_test/arrow_to_otlp_test.go
+++ b/pkg/otel/metrics_test/arrow_to_otlp_test.go
@@ -15,6 +15,7 @@
 package metrics_test
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/f5/otel-arrow-adapter/pkg/air"
@@ -29,7 +30,9 @@ func TestSystemCpuTimeConversion(t *testing.T) {
 
 	cfg := config.NewUint8DefaultConfig()
 	rr := air.NewRecordRepository(cfg)
-	lg := datagen.NewMetricsGenerator(datagen.DefaultResourceAttributes(), datagen.DefaultInstrumentationScopes())
+	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+
+	lg := datagen.NewMetricsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 
 	multivariateConf := metrics.MultivariateMetricsConfig{
 		Metrics: make(map[string]string),
@@ -60,7 +63,8 @@ func TestSystemMemoryUsageConversion(t *testing.T) {
 
 	cfg := config.NewUint8DefaultConfig()
 	rr := air.NewRecordRepository(cfg)
-	lg := datagen.NewMetricsGenerator(datagen.DefaultResourceAttributes(), datagen.DefaultInstrumentationScopes())
+	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+	lg := datagen.NewMetricsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 
 	multivariateConf := metrics.MultivariateMetricsConfig{
 		Metrics: make(map[string]string),
@@ -91,7 +95,9 @@ func TestSystemCpuLoadAverage1mConversion(t *testing.T) {
 
 	cfg := config.NewUint8DefaultConfig()
 	rr := air.NewRecordRepository(cfg)
-	lg := datagen.NewMetricsGenerator(datagen.DefaultResourceAttributes(), datagen.DefaultInstrumentationScopes())
+	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+
+	lg := datagen.NewMetricsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 
 	multivariateConf := metrics.MultivariateMetricsConfig{
 		Metrics: make(map[string]string),

--- a/pkg/otel/metrics_test/otlp_to_arrow_test.go
+++ b/pkg/otel/metrics_test/otlp_to_arrow_test.go
@@ -15,6 +15,7 @@
 package metrics_test
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/f5/otel-arrow-adapter/pkg/air"
@@ -29,7 +30,9 @@ func TestOtlpMetricsToArrowRecords(t *testing.T) {
 
 	cfg := config.NewUint8DefaultConfig()
 	rr := air.NewRecordRepository(cfg)
-	lg := datagen.NewMetricsGenerator(datagen.DefaultResourceAttributes(), datagen.DefaultInstrumentationScopes())
+	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+
+	lg := datagen.NewMetricsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 
 	multivariateConf := metrics.MultivariateMetricsConfig{
 		Metrics: make(map[string]string),

--- a/pkg/otel/traces/validation_test.go
+++ b/pkg/otel/traces/validation_test.go
@@ -16,6 +16,7 @@ package traces_test
 
 import (
 	"encoding/json"
+	"math/rand"
 	"testing"
 
 	"github.com/apache/arrow/go/v11/arrow/memory"
@@ -35,7 +36,9 @@ import (
 func TestConversionFromSyntheticData(t *testing.T) {
 	t.Parallel()
 
-	tracesGen := datagen.NewTracesGenerator(datagen.DefaultResourceAttributes(), datagen.DefaultInstrumentationScopes())
+	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+
+	tracesGen := datagen.NewTracesGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 
 	// Generate a random OTLP traces request.
 	expectedRequest := ptraceotlp.NewExportRequestFromTraces(tracesGen.Generate(10, 100))

--- a/tools/logs_gen/main.go
+++ b/tools/logs_gen/main.go
@@ -20,6 +20,7 @@ package main
 import (
 	"flag"
 	"log"
+	"math/rand"
 	"os"
 	"path"
 
@@ -47,7 +48,8 @@ func main() {
 	}
 
 	// Generate the dataset.
-	generator := datagen.NewLogsGenerator(datagen.DefaultResourceAttributes(), datagen.DefaultInstrumentationScopes())
+	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+	generator := datagen.NewLogsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 	request := plogotlp.NewRequestFromLogs(generator.Generate(batchSize, 100))
 
 	// Marshal the request to bytes.

--- a/tools/metrics_gen/main.go
+++ b/tools/metrics_gen/main.go
@@ -20,6 +20,7 @@ package main
 import (
 	"flag"
 	"log"
+	"math/rand"
 	"os"
 	"path"
 
@@ -47,7 +48,9 @@ func main() {
 	}
 
 	// Generate the dataset.
-	generator := datagen.NewMetricsGenerator(datagen.DefaultResourceAttributes(), datagen.DefaultInstrumentationScopes())
+	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+
+	generator := datagen.NewMetricsGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 	request := pmetricotlp.NewRequestFromMetrics(generator.Generate(batchSize, 100))
 
 	// Marshal the request to bytes.

--- a/tools/trace_gen/main.go
+++ b/tools/trace_gen/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"flag"
 	"log"
+	"math/rand"
 	"os"
 	"path"
 
@@ -45,7 +46,8 @@ func main() {
 	}
 
 	// Generate the dataset.
-	generator := datagen.NewTracesGenerator(datagen.DefaultResourceAttributes(), datagen.DefaultInstrumentationScopes())
+	entropy := datagen.NewTestEntropy(int64(rand.Uint64()))
+	generator := datagen.NewTracesGenerator(entropy, entropy.NewStandardResourceAttributes(), entropy.NewStandardInstrumentationScopes())
 	request := ptraceotlp.NewRequestFromTraces(generator.Generate(batchSize, 100))
 
 	// Marshal the request to bytes.


### PR DESCRIPTION
This changes the data generator to be deterministic , which makes the cases identified by the fuzzer reproducible.

Then, running `go test -fuzz .` in `pkg/otel/arrow_record` begins searching for problematic inputs. The test framework saves data to a local `testdata` directory, which helps it go faster on subsequent runs.

The first test case I discovered causes the process under test to OOM.

```
go test -v -run=FuzzProducerConsumerTraces/bd53d08feeddb625ad75ac78e4f9b018e408ef38f6a49ddf9715b12f7d2def16
```
