### PR TITLE
Add producer fuzz tests

### DIFF
--- a/pkg/otel/arrow_record/producer_consumer_test.go
+++ b/pkg/otel/arrow_record/producer_consumer_test.go
@@ -15,6 +15,10 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// Fuzz-tests the consumer on a sequence of two OTLP protobuf inputs.
+// Note: This is basically a fuzz-tester of the Arrow IPC library.
+// TODO: Note we can add a memory allocator to limit some of the memory
+// allocated by Arrow, but not all of it.
 func FuzzConsumerTraces(f *testing.F) {
 	const numSeeds = 5
 
@@ -64,6 +68,7 @@ func FuzzConsumerTraces(f *testing.F) {
 	})
 }
 
+// Fuzz-tests the producer on a sequence of two OTLP protobuf inputs.
 func FuzzProducerTraces2(f *testing.F) {
 	const numSeeds = 5
 
@@ -112,6 +117,7 @@ func FuzzProducerTraces2(f *testing.F) {
 	})
 }
 
+// Fuzz-tests the producer on the second in sequence of two OTLP protobuf inputs.
 func FuzzProducerTraces1(f *testing.F) {
 	const numSeeds = 5
 


### PR DESCRIPTION
Adds two fuzz tests for the producer. By running FuzzProducerTraces1 I was able to find a reproducible problem that overflows the runtime stack size limit.

Looks like

```
go test -run=FuzzProducerTraces1/2359294d4ee605f162f65e8ed838513aea159c4da9d038f02bf5e1018a836d0a
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0x140207603a0 stack=[0x14020760000, 0x14040760000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x1014c0e9b?, 0x101e596e0?})
	/usr/local/go/src/runtime/panic.go:1047 +0x40 fp=0x16f28ed50 sp=0x16f28ed20 pc=0x100cbb690
runtime.newstack()
	/usr/local/go/src/runtime/stack.go:1103 +0x464 fp=0x16f28ef00 sp=0x16f28ed50 pc=0x100cd60c4
runtime.morestack()
	/usr/local/go/src/runtime/asm_arm64.s:316 +0x70 fp=0x16f28ef00 sp=0x16f28ef00 pc=0x100cece00

goroutine 5 [running]:
github.com/apache/arrow/go/v11/arrow/array.NewBinaryBuilder.func2(0x0?)
	/Users/josh.macdonald/src/lightstep/go/pkg/mod/github.com/apache/arrow/go/v11@v11.0.0-20221108144011-89a65b06a199/arrow/array/binarybuilder.go:61 +0xa8 fp=0x140207603a0 sp=0x140207603a0 pc=0x101212e98
github.com/apache/arrow/go/v11/arrow/array.(*BinaryBuilder).Value(0x14000212580, 0x0)
	/Users/josh.macdonald/src/lightstep/go/pkg/mod/github.com/apache/arrow/go/v11@v11.0.0-20221108144011-89a65b06a199/arrow/array/binarybuilder.go:177 +0x30 fp=0x140207603d0 sp=0x140207603a0 pc=0x1012136a0
github.com/apache/arrow/go/v11/internal/hashing.(*BinaryMemoTable).findOffset(0x140000f5fe0, 0x0)
	/Users/josh.macdonald/src/lightstep/go/pkg/mod/github.com/apache/arrow/go/v11@v11.0.0-20221108144011-89a65b06a199/internal/hashing/xxh3_memo_table.go:345 +0x34 fp=0x14020760410 sp=0x140207603d0 pc=0x10120c8e4
github.com/apache/arrow/go/v11/internal/hashing.(*BinaryMemoTable).findOffset(0x140000f5fe0, 0x0)
	/Users/josh.macdonald/src/lightstep/go/pkg/mod/github.com/apache/arrow/go/v11@v11.0.0-20221108144011-89a65b06a199/internal/hashing/xxh3_memo_table.go:356 +0xc8 fp=0x14020760450 sp=0x14020760410 pc=0x10120c978
github.com/apache/arrow/go/v11/internal/hashing.(*BinaryMemoTable).findOffset(0x140000f5fe0, 0x0)
	/Users/josh.macdonald/src/lightstep/go/pkg/mod/github.com/apache/arrow/go/v11@v11.0.0-20221108144011-89a65b06a199/internal/hashing/xxh3_memo_table.go:356 +0xc8 fp=0x14020760490 sp=0x14020760450 pc=0x10120c978
github.com/apache/arrow/go/v11/internal/hashing.(*BinaryMemoTable).findOffset(0x140000f5fe0, 0x0)
	/Users/josh.macdonald/src/lightstep/go/pkg/mod/github.com/apache/arrow/go/v11@v11.0.0-20221108144011-89a65b06a199/internal/hashing/xxh3_memo_table.go:
...
```