### PR TITLE
Memory leak issue in otlp arrow producer

### DIFF
--- a/pkg/otel/arrow_record/consumer.go
+++ b/pkg/otel/arrow_record/consumer.go
@@ -39,6 +39,7 @@ type ConsumerAPI interface {
 	LogsFrom(*colarspb.BatchArrowRecords) ([]plog.Logs, error)
 	TracesFrom(*colarspb.BatchArrowRecords) ([]ptrace.Traces, error)
 	MetricsFrom(*colarspb.BatchArrowRecords) ([]pmetric.Metrics, error)
+	Close() error
 }
 
 var _ ConsumerAPI = &Consumer{}
@@ -172,4 +173,14 @@ func (c *Consumer) Consume(bar *colarspb.BatchArrowRecords) ([]*RecordMessage, e
 	}
 
 	return ibes, nil
+}
+
+// Close closes the consumer and all its sub-stream ipc readers.
+func (c *Consumer) Close() error {
+	for _, sc := range c.streamConsumers {
+		if sc.ipcReader != nil {
+			sc.ipcReader.Release()
+		}
+	}
+	return nil
 }

--- a/pkg/otel/arrow_record/mock/mock.go
+++ b/pkg/otel/arrow_record/mock/mock.go
@@ -82,6 +82,20 @@ func (mr *MockProducerAPIMockRecorder) BatchArrowRecordsFromTraces(arg0 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchArrowRecordsFromTraces", reflect.TypeOf((*MockProducerAPI)(nil).BatchArrowRecordsFromTraces), arg0)
 }
 
+// Close mocks base method.
+func (m *MockProducerAPI) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockProducerAPIMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockProducerAPI)(nil).Close))
+}
+
 // MockConsumerAPI is a mock of ConsumerAPI interface.
 type MockConsumerAPI struct {
 	ctrl     *gomock.Controller
@@ -103,6 +117,20 @@ func NewMockConsumerAPI(ctrl *gomock.Controller) *MockConsumerAPI {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockConsumerAPI) EXPECT() *MockConsumerAPIMockRecorder {
 	return m.recorder
+}
+
+// Close mocks base method.
+func (m *MockConsumerAPI) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockConsumerAPIMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockConsumerAPI)(nil).Close))
 }
 
 // LogsFrom mocks base method.

--- a/pkg/otel/arrow_record/producer.go
+++ b/pkg/otel/arrow_record/producer.go
@@ -36,6 +36,7 @@ type ProducerAPI interface {
 	BatchArrowRecordsFromTraces(ptrace.Traces) (*colarspb.BatchArrowRecords, error)
 	BatchArrowRecordsFromLogs(plog.Logs) (*colarspb.BatchArrowRecords, error)
 	BatchArrowRecordsFromMetrics(pmetric.Metrics) (*colarspb.BatchArrowRecords, error)
+	Close() error
 }
 
 var _ ProducerAPI = &Producer{}

--- a/pkg/otel/arrow_record/producer_consumer_test.go
+++ b/pkg/otel/arrow_record/producer_consumer_test.go
@@ -177,7 +177,7 @@ func TestProducerConsumerTraces(t *testing.T) {
 	traces := dg.Generate(10, time.Minute)
 
 	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
-	//defer pool.AssertSize(t, 0)
+	defer pool.AssertSize(t, 0)
 
 	producer := NewProducerWithPool(pool)
 
@@ -206,7 +206,10 @@ func TestProducerConsumerLogs(t *testing.T) {
 	)
 	logs := dg.Generate(10, time.Minute)
 
-	producer := NewProducer()
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	producer := NewProducerWithPool(pool)
 
 	batch, err := producer.BatchArrowRecordsFromLogs(logs)
 	require.NoError(t, err)
@@ -233,7 +236,10 @@ func TestProducerConsumerMetrics(t *testing.T) {
 	)
 	metrics := dg.Generate(10, time.Minute)
 
-	producer := NewProducer()
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	producer := NewProducerWithPool(pool)
 
 	batch, err := producer.BatchArrowRecordsFromMetrics(metrics)
 	require.NoError(t, err)
@@ -253,7 +259,10 @@ func TestProducerConsumerMetrics(t *testing.T) {
 func TestProducerConsumer(t *testing.T) {
 	t.Parallel()
 
-	producer := NewProducer()
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
+	producer := NewProducerWithPool(pool)
 	consumer := NewConsumer()
 	config := cfg.NewUint8DefaultConfig()
 	rr := air.NewRecordRepository(config)

--- a/pkg/otel/arrow_record/producer_consumer_test.go
+++ b/pkg/otel/arrow_record/producer_consumer_test.go
@@ -32,25 +32,32 @@ func FuzzConsumerTraces(f *testing.F) {
 	ent := datagen.NewTestEntropy(12345)
 
 	for i := 0; i < numSeeds; i++ {
-		dg := datagen.NewTracesGenerator(
-			ent,
-			ent.NewStandardResourceAttributes(),
-			ent.NewStandardInstrumentationScopes(),
-		)
-		traces1 := dg.Generate(i+1, time.Minute)
-		traces2 := dg.Generate(i+1, time.Minute)
+		func() {
+			dg := datagen.NewTracesGenerator(
+				ent,
+				ent.NewStandardResourceAttributes(),
+				ent.NewStandardInstrumentationScopes(),
+			)
+			traces1 := dg.Generate(i+1, time.Minute)
+			traces2 := dg.Generate(i+1, time.Minute)
 
-		producer := NewProducer()
+			producer := NewProducer()
+			defer func() {
+				if err := producer.Close(); err != nil {
+					f.Error("unexpected fail", err)
+				}
+			}()
 
-		batch1, err1 := producer.BatchArrowRecordsFromTraces(traces1)
-		require.NoError(f, err1)
-		batch2, err2 := producer.BatchArrowRecordsFromTraces(traces2)
-		require.NoError(f, err2)
+			batch1, err1 := producer.BatchArrowRecordsFromTraces(traces1)
+			require.NoError(f, err1)
+			batch2, err2 := producer.BatchArrowRecordsFromTraces(traces2)
+			require.NoError(f, err2)
 
-		b1b, err1 := proto.Marshal(batch1)
-		b2b, err2 := proto.Marshal(batch2)
+			b1b, err1 := proto.Marshal(batch1)
+			b2b, err2 := proto.Marshal(batch2)
 
-		f.Add(b1b, b2b)
+			f.Add(b1b, b2b)
+		}()
 	}
 
 	f.Fuzz(func(t *testing.T, b1, b2 []byte) {
@@ -114,6 +121,11 @@ func FuzzProducerTraces2(f *testing.F) {
 		}
 
 		producer := NewProducer()
+		defer func() {
+			if err := producer.Close(); err != nil {
+				t.Error("unexpected fail", err)
+			}
+		}()
 
 		if _, err := producer.BatchArrowRecordsFromTraces(e1.Traces()); err != nil {
 			return
@@ -156,6 +168,11 @@ func FuzzProducerTraces1(f *testing.F) {
 		}
 
 		producer := NewProducer()
+		defer func() {
+			if err := producer.Close(); err != nil {
+				t.Error("unexpected fail", err)
+			}
+		}()
 
 		if _, err := producer.BatchArrowRecordsFromTraces(traces1); err != nil {
 			t.Error("unexpected fail", err)
@@ -176,10 +193,16 @@ func TestProducerConsumerTraces(t *testing.T) {
 	)
 	traces := dg.Generate(10, time.Minute)
 
+	// Check memory leak issue.
 	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer pool.AssertSize(t, 0)
 
 	producer := NewProducerWithPool(pool)
+	defer func() {
+		if err := producer.Close(); err != nil {
+			t.Error("unexpected fail", err)
+		}
+	}()
 
 	batch, err := producer.BatchArrowRecordsFromTraces(traces)
 	require.NoError(t, err)
@@ -206,10 +229,16 @@ func TestProducerConsumerLogs(t *testing.T) {
 	)
 	logs := dg.Generate(10, time.Minute)
 
+	// Check memory leak issue.
 	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer pool.AssertSize(t, 0)
 
 	producer := NewProducerWithPool(pool)
+	defer func() {
+		if err := producer.Close(); err != nil {
+			t.Error("unexpected fail", err)
+		}
+	}()
 
 	batch, err := producer.BatchArrowRecordsFromLogs(logs)
 	require.NoError(t, err)
@@ -236,10 +265,16 @@ func TestProducerConsumerMetrics(t *testing.T) {
 	)
 	metrics := dg.Generate(10, time.Minute)
 
+	// Check memory leak issue.
 	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer pool.AssertSize(t, 0)
 
 	producer := NewProducerWithPool(pool)
+	defer func() {
+		if err := producer.Close(); err != nil {
+			t.Error("unexpected fail", err)
+		}
+	}()
 
 	batch, err := producer.BatchArrowRecordsFromMetrics(metrics)
 	require.NoError(t, err)
@@ -259,10 +294,17 @@ func TestProducerConsumerMetrics(t *testing.T) {
 func TestProducerConsumer(t *testing.T) {
 	t.Parallel()
 
+	// Check memory leak issue.
 	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer pool.AssertSize(t, 0)
 
 	producer := NewProducerWithPool(pool)
+	defer func() {
+		if err := producer.Close(); err != nil {
+			t.Error("unexpected fail", err)
+		}
+	}()
+
 	consumer := NewConsumer()
 	config := cfg.NewUint8DefaultConfig()
 	rr := air.NewRecordRepository(config)


### PR DESCRIPTION
Issue: #53 

Each `ipc.Writer` must be closed after usage to avoid this type of memory leak.
A method `Producer.Close` has been added and the code/tests has been updated accordingly.

@jmacd in the collector you must call the `Close` method for each producer created.