### PR TITLE
Generate Arrow Schema documentation from code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ as the end-to-end performance between telemetry data producers and receivers.
 exporter and receiver](https://github.com/open-telemetry/experimental-arrow-collector).
 
 Other important links:
+- [OTEP/Specification](https://github.com/lquerel/oteps/blob/main/text/0156-columnar-encoding.md) describing the
+  motivations, the protocol, the schemas, the benchmark results and the different phases of this project. The OTEP is
+  still [pending, unmerged](https://github.com/open-telemetry/oteps/pull/171).
+- [Donation proposal](https://github.com/open-telemetry/community/issues/1332) under review.
 - [Project Roadmap](https://github.com/f5/otel-arrow-adapter/milestones?direction=asc&sort=due_date&state=open) and [project Board](https://github.com/orgs/f5/projects/1/views/2) describing the current state of the project.
-- [OTEP/Specification](https://github.com/lquerel/oteps/blob/main/text/0156-columnar-encoding.md) describing the 
-motivations, the protocol, the schemas, the benchmark results and the different phases of this project.
 - [Arrow schemas](docs/arrow_schema.md) used by this package.
-- [Thread model](docs/threat_model_assessment.md).
+- [Threat model](docs/threat_model_assessment.md).
 
 ## Phase 1 (current implementation)
 

--- a/tools/doc_schema_gen/main.go
+++ b/tools/doc_schema_gen/main.go
@@ -1,0 +1,266 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/apache/arrow/go/v11/arrow"
+
+	logsarrow "github.com/f5/otel-arrow-adapter/pkg/otel/logs/arrow"
+	metricsarrow "github.com/f5/otel-arrow-adapter/pkg/otel/metrics/arrow"
+	tracesarrow "github.com/f5/otel-arrow-adapter/pkg/otel/traces/arrow"
+)
+
+func main() {
+	sdg := NewSchemaDocGenerator().
+		reusableField("attributes", "shared_attributes").
+		reusableField("exemplars").
+		comment("flags", "used as a bit mask").
+		comment("shared_attributes", "inherited by data points").
+		comment("shared_start_time_unix_nano", "inherited by data points").
+		comment("shared_time_unix_nano", "inherited by data points").
+		comment("severity_number", "OTLP enum with 25 variants").
+		comment("aggregation_temporality", "OTLP enum with 3 variants").
+		comment("kind", "OTLP enum with 6 variants").
+		comment("code", "OTLP enum with 4 variants")
+
+	sdg.genSchemaDoc(metricsarrow.Schema, 2)
+	sdg.genSchemaDoc(logsarrow.Schema, 2)
+	sdg.genSchemaDoc(tracesarrow.Schema, 2)
+
+	sdg.printDoc(2)
+}
+
+type SchemaDocGenerator struct {
+	reusableFields  map[string]*[]Line
+	defaultComments map[string]string
+	doc             []Line
+	currentDoc      *[]Line
+}
+
+func NewSchemaDocGenerator() *SchemaDocGenerator {
+	sdg := SchemaDocGenerator{
+		reusableFields:  make(map[string]*[]Line),
+		defaultComments: make(map[string]string),
+		doc:             make([]Line, 0, 100),
+	}
+	sdg.currentDoc = &sdg.doc
+	return &sdg
+}
+
+type Line struct {
+	indent  string
+	field   string
+	comment string
+}
+
+func (sdg *SchemaDocGenerator) printDoc(minSpaceBeforeComment int) {
+	printDocElement := func() {
+		var fmtLines []*strings.Builder
+		maxLen := 0
+
+		for _, line := range *sdg.currentDoc {
+			var fmtLine strings.Builder
+			fmtLine.WriteString(fmt.Sprintf("%s%s", line.indent, line.field))
+			if fmtLine.Len() > maxLen {
+				maxLen = fmtLine.Len()
+			}
+			fmtLines = append(fmtLines, &fmtLine)
+		}
+
+		charsBeforeComment := maxLen + minSpaceBeforeComment
+		for i, line := range *sdg.currentDoc {
+			fmtLine := fmtLines[i]
+			spaces := charsBeforeComment - fmtLine.Len()
+			if len(line.comment) > 0 {
+				fmtLine.WriteString(strings.Repeat(" ", spaces))
+				fmtLine.WriteString(fmt.Sprintf("# %s", line.comment))
+			}
+			println(fmtLine.String())
+		}
+	}
+
+	for _, doc := range sdg.reusableFields {
+		sdg.currentDoc = doc
+		printDocElement()
+		println("---\n")
+	}
+
+	sdg.currentDoc = &sdg.doc
+	printDocElement()
+}
+
+func (sdg *SchemaDocGenerator) reusableField(fieldNames ...string) *SchemaDocGenerator {
+	doc := make([]Line, 0, 100)
+	for _, fieldName := range fieldNames {
+		sdg.reusableFields[fieldName] = &doc
+	}
+	return sdg
+}
+
+func (sdg *SchemaDocGenerator) comment(fieldName string, comment string) *SchemaDocGenerator {
+	sdg.defaultComments[fieldName] = comment
+	return sdg
+}
+
+func (sdg *SchemaDocGenerator) genSchemaDoc(schema *arrow.Schema, spacesPerIndent int) {
+	for _, field := range schema.Fields() {
+		sdg.genFieldDoc("", spacesPerIndent, false, "", &field)
+	}
+	*sdg.currentDoc = append(*sdg.currentDoc, Line{indent: "", field: "---\n", comment: ""})
+}
+
+func (sdg *SchemaDocGenerator) genFieldDoc(indent string, spacesPerIndent int, inList bool, prefix string, field *arrow.Field) {
+	reusableFieldDoc, reusableFieldFound := sdg.reusableFields[field.Name]
+	localCurrentDoc := sdg.currentDoc
+	if reusableFieldFound {
+		sdg.currentDoc = reusableFieldDoc
+		defer func() { sdg.currentDoc = localCurrentDoc }()
+	}
+
+	// Mute intermediary level in Arrow list
+	if !inList {
+		yamlType, comment := sdg.arrowTypeToYamlType(field.Type)
+
+		if reusableFieldFound {
+			*localCurrentDoc = append(*localCurrentDoc, Line{indent: indent, field: fmt.Sprintf("%s%s: *%s", prefix, field.Name, field.Name), comment: sdg.genComment(field, comment)})
+			if len(*reusableFieldDoc) == 0 {
+				*reusableFieldDoc = append(*reusableFieldDoc, Line{indent: "", field: fmt.Sprintf("%s%s: &%s", prefix, field.Name, field.Name), comment: sdg.genComment(field, comment)})
+				indent = ""
+			} else {
+				return
+			}
+		} else {
+			*sdg.currentDoc = append(*sdg.currentDoc, Line{indent: indent, field: fmt.Sprintf("%s%s: %s", prefix, field.Name, yamlType), comment: sdg.genComment(field, comment)})
+		}
+	}
+
+	// List indentation must not be propagated to children
+	indent = strings.ReplaceAll(indent, "-", " ")
+
+	switch t := field.Type.(type) {
+	case *arrow.StructType:
+		indent += strings.Repeat(" ", spacesPerIndent)
+		for i, child := range t.Fields() {
+			newIndent := indent
+			if inList {
+				if i == 0 {
+					newIndent += "- "
+				} else {
+					newIndent += "  "
+				}
+			}
+			sdg.genFieldDoc(newIndent, spacesPerIndent, false, prefix, &child)
+		}
+	case *arrow.ListType:
+		sdg.genFieldDoc(indent, spacesPerIndent, true, "", &arrow.Field{Name: "", Type: t.Elem()})
+	case *arrow.SparseUnionType:
+		indent += strings.Repeat(" ", spacesPerIndent)
+		for _, child := range t.Fields() {
+			sdg.genFieldDoc(indent, spacesPerIndent, false, prefix, &child)
+		}
+	case *arrow.DenseUnionType:
+		indent += strings.Repeat(" ", spacesPerIndent)
+		for _, child := range t.Fields() {
+			sdg.genFieldDoc(indent, spacesPerIndent, false, prefix, &child)
+		}
+	case *arrow.MapType:
+		indent += strings.Repeat(" ", spacesPerIndent)
+		sdg.genFieldDoc(indent, spacesPerIndent, false, prefix, &arrow.Field{Name: "key", Type: t.KeyType()})
+		sdg.genFieldDoc(indent, spacesPerIndent, false, prefix, &arrow.Field{Name: "value", Type: t.ItemType()})
+	}
+}
+
+func (sdg *SchemaDocGenerator) genComment(field *arrow.Field, otherComment string) string {
+	addComment := func(comment string, otherComment string) string {
+		if len(comment) > 0 {
+			comment += ", "
+		}
+		comment += otherComment
+		return comment
+	}
+
+	comment := ""
+	switch t := field.Type.(type) {
+	//case *arrow.StructType:
+	//	comment = "arrow struct"
+	case *arrow.ListType:
+		dt, _ := sdg.arrowTypeToYamlType(t.Elem())
+		comment = fmt.Sprintf("arrow list of %s", dt)
+	case *arrow.SparseUnionType:
+		comment = "arrow sparse union"
+	case *arrow.DenseUnionType:
+		comment = "arrow dense union"
+	case *arrow.MapType:
+		comment = "arrow map"
+	}
+	if len(otherComment) > 0 {
+		comment = addComment(comment, otherComment)
+	}
+	if defaultComment, found := sdg.defaultComments[field.Name]; found {
+		comment = addComment(comment, defaultComment)
+	}
+	return comment
+}
+
+func (sdg *SchemaDocGenerator) arrowTypeToYamlType(dt arrow.DataType) (string, string) {
+	switch t := dt.(type) {
+	case *arrow.Uint8Type:
+		return "uint8", ""
+	case *arrow.Uint16Type:
+		return "uint16", ""
+	case *arrow.Uint32Type:
+		return "uint32", ""
+	case *arrow.Uint64Type:
+		return "uint64", ""
+	case *arrow.Int8Type:
+		return "int8", ""
+	case *arrow.Int16Type:
+		return "int16", ""
+	case *arrow.Int32Type:
+		return "int32", ""
+	case *arrow.Int64Type:
+		return "int64", ""
+	case *arrow.Float32Type:
+		return "float32", ""
+	case *arrow.Float64Type:
+		return "float64", ""
+	case *arrow.StringType:
+		return "string", ""
+	case *arrow.BinaryType:
+		return "binary", ""
+	case *arrow.BooleanType:
+		return "bool", ""
+	case *arrow.TimestampType:
+		return "timestamp", "time unit nanoseconds"
+	case *arrow.DictionaryType:
+		baseType, comment := sdg.arrowTypeToYamlType(t.ValueType)
+		if len(comment) > 0 {
+			comment += ", "
+		}
+		comment += fmt.Sprintf("%s_dictionary by default, fallback to %s when cardinality too high", baseType, baseType)
+		return fmt.Sprintf("%s_dictionary | %s", baseType, baseType), comment
+	case *arrow.FixedSizeBinaryType:
+		return fmt.Sprintf("%d_bytes_binary", t.ByteWidth), "arrow fixed size binary array"
+	case *arrow.StructType:
+		return "struct", ""
+	}
+	return "", ""
+}


### PR DESCRIPTION
This PR aims to generate a YAML representation of each Arrow schema used in this project in order to have a synchronized schema documentation in this project and in the corresponding OTEP.

GH issue: #79 

EDIT:  The SchemaDocGen CLI  generates the following YAML schema declaration based on the source code.
```yaml
attributes: &attributes                 # arrow map
  key: string_dictionary | string       # string_dictionary by default, fallback to string when cardinality too high
  value:                                # arrow sparse union
    str: string_dictionary | string     # string_dictionary by default, fallback to string when cardinality too high
    i64: int64
    f64: float64
    bool: bool
    binary: binary_dictionary | binary  # binary_dictionary by default, fallback to binary when cardinality too high
---

attributes: &attributes                 # arrow map
  key: string_dictionary | string       # string_dictionary by default, fallback to string when cardinality too high
  value:                                # arrow sparse union
    str: string_dictionary | string     # string_dictionary by default, fallback to string when cardinality too high
    i64: int64
    f64: float64
    bool: bool
    binary: binary_dictionary | binary  # binary_dictionary by default, fallback to binary when cardinality too high
---

exemplars: &exemplars                                       # arrow list of struct
  - attributes: *attributes                                 # arrow map
    time_unix_nano: timestamp                               # time unit nanoseconds
    value:                                                  # arrow sparse union
      i64: int64
      f64: float64
    span_id: 8_bytes_binary_dictionary | 8_bytes_binary     # arrow fixed size binary array, 8_bytes_binary_dictionary by default, fallback to 8_bytes_binary when cardinality too high
    trace_id: 16_bytes_binary_dictionary | 16_bytes_binary  # arrow fixed size binary array, 16_bytes_binary_dictionary by default, fallback to 16_bytes_binary when cardinality too high
---

resource_metrics:                                                       # arrow list of struct
  - resource: struct
      attributes: *attributes                                           # arrow map
      dropped_attributes_count: uint32
    schema_url: string_dictionary | string                              # string_dictionary by default, fallback to string when cardinality too high
    scope_metrics:                                                      # arrow list of struct
      - scope: struct
          name: string_dictionary | string                              # string_dictionary by default, fallback to string when cardinality too high
          version: string_dictionary | string                           # string_dictionary by default, fallback to string when cardinality too high
          attributes: *attributes                                       # arrow map
          dropped_attributes_count: uint32
        schema_url: string_dictionary | string                          # string_dictionary by default, fallback to string when cardinality too high
        univariate_metrics:                                             # arrow list of struct
          - name: string_dictionary | string                            # string_dictionary by default, fallback to string when cardinality too high
            description: string_dictionary | string                     # string_dictionary by default, fallback to string when cardinality too high
            unit: string_dictionary | string                            # string_dictionary by default, fallback to string when cardinality too high
            data:                                                       # arrow sparse union
              gauge: struct
                data_points:                                            # arrow list of struct
                  - attributes: *attributes                             # arrow map
                    start_time_unix_nano: timestamp                     # time unit nanoseconds
                    time_unix_nano: timestamp                           # time unit nanoseconds
                    value:                                              # arrow sparse union
                      i64: int64
                      f64: float64
                    exemplars: *exemplars                               # arrow list of struct
                    flags: uint32                                       # used as a bit mask
              sum: struct
                data_points:                                            # arrow list of struct
                  - attributes: *attributes                             # arrow map
                    start_time_unix_nano: timestamp                     # time unit nanoseconds
                    time_unix_nano: timestamp                           # time unit nanoseconds
                    value:                                              # arrow sparse union
                      i64: int64
                      f64: float64
                    exemplars: *exemplars                               # arrow list of struct
                    flags: uint32                                       # used as a bit mask
                aggregation_temporality: int32_dictionary | int32       # int32_dictionary by default, fallback to int32 when cardinality too high, OTLP enum with 3 variants
                is_monotonic: bool
              summary: struct
                data_points:                                            # arrow list of struct
                  - attributes: *attributes                             # arrow map
                    start_time_unix_nano: timestamp                     # time unit nanoseconds
                    time_unix_nano: timestamp                           # time unit nanoseconds
                    count: uint64
                    sum: float64
                    quantile:                                           # arrow list of struct
                      - quantile: float64
                        value: float64
                    flags: uint32                                       # used as a bit mask
              histogram: struct
                data_points:                                            # arrow list of struct
                  - attributes: *attributes                             # arrow map
                    start_time_unix_nano: timestamp                     # time unit nanoseconds
                    time_unix_nano: timestamp                           # time unit nanoseconds
                    count: uint64
                    sum: float64
                    bucket_counts:                                      # arrow list of uint64
                    explicit_bounds:                                    # arrow list of float64
                    exemplars: *exemplars                               # arrow list of struct
                    flags: uint32                                       # used as a bit mask
                    min: float64
                    max: float64
                aggregation_temporality: int32_dictionary | int32       # int32_dictionary by default, fallback to int32 when cardinality too high, OTLP enum with 3 variants
              exp_histogram: struct
                data_points:                                            # arrow list of struct
                  - attributes: *attributes                             # arrow map
                    start_time_unix_nano: timestamp                     # time unit nanoseconds
                    time_unix_nano: timestamp                           # time unit nanoseconds
                    count: uint64
                    sum: float64
                    scale: int32
                    zero_count: uint64
                    positive: struct
                      offset: int32
                      bucket_counts:                                    # arrow list of uint64
                    negative: struct
                      offset: int32
                      bucket_counts:                                    # arrow list of uint64
                    exemplars: *exemplars                               # arrow list of struct
                    flags: uint32                                       # used as a bit mask
                    min: float64
                    max: float64
                aggregation_temporality: int32_dictionary | int32       # int32_dictionary by default, fallback to int32 when cardinality too high, OTLP enum with 3 variants
            shared_attributes: *shared_attributes                       # arrow map, inherited by data points
            shared_start_time_unix_nano: timestamp                      # time unit nanoseconds, inherited by data points
            shared_time_unix_nano: timestamp                            # time unit nanoseconds, inherited by data points
        shared_attributes: *shared_attributes                           # arrow map, inherited by data points
        shared_start_time_unix_nano: timestamp                          # time unit nanoseconds, inherited by data points
        shared_time_unix_nano: timestamp                                # time unit nanoseconds, inherited by data points
---

resource_logs:                                                          # arrow list of struct
  - resource: struct
      attributes: *attributes                                           # arrow map
      dropped_attributes_count: uint32
    schema_url: string_dictionary | string                              # string_dictionary by default, fallback to string when cardinality too high
    scope_logs:                                                         # arrow list of struct
      - scope: struct
          name: string_dictionary | string                              # string_dictionary by default, fallback to string when cardinality too high
          version: string_dictionary | string                           # string_dictionary by default, fallback to string when cardinality too high
          attributes: *attributes                                       # arrow map
          dropped_attributes_count: uint32
        schema_url: string_dictionary | string                          # string_dictionary by default, fallback to string when cardinality too high
        logs:                                                           # arrow list of struct
          - time_unix_nano: timestamp                                   # time unit nanoseconds
            observed_time_unix_nano: timestamp                          # time unit nanoseconds
            trace_id: 16_bytes_binary_dictionary | 16_bytes_binary      # arrow fixed size binary array, 16_bytes_binary_dictionary by default, fallback to 16_bytes_binary when cardinality too high
            span_id: 8_bytes_binary_dictionary | 8_bytes_binary         # arrow fixed size binary array, 8_bytes_binary_dictionary by default, fallback to 8_bytes_binary when cardinality too high
            severity_number: int32_dictionary | int32                   # int32_dictionary by default, fallback to int32 when cardinality too high, OTLP enum with 25 variants
            severity_text: string_dictionary | string                   # string_dictionary by default, fallback to string when cardinality too high
            body:                                                       # arrow sparse union
              str: string_dictionary | string                           # string_dictionary by default, fallback to string when cardinality too high
              i64: int64
              f64: float64
              bool: bool
              binary: binary_dictionary | binary                        # binary_dictionary by default, fallback to binary when cardinality too high
            attributes: *attributes                                     # arrow map
            dropped_attributes_count: uint32
            flags: uint32                                               # used as a bit mask
---

resource_spans:                                                         # arrow list of struct
  - resource: struct
      attributes: *attributes                                           # arrow map
      dropped_attributes_count: uint32
    schema_url: string_dictionary | string                              # string_dictionary by default, fallback to string when cardinality too high
    scope_spans:                                                        # arrow list of struct
      - scope: struct
          name: string_dictionary | string                              # string_dictionary by default, fallback to string when cardinality too high
          version: string_dictionary | string                           # string_dictionary by default, fallback to string when cardinality too high
          attributes: *attributes                                       # arrow map
          dropped_attributes_count: uint32
        schema_url: string_dictionary | string                          # string_dictionary by default, fallback to string when cardinality too high
        spans:                                                          # arrow list of struct
          - start_time_unix_nano: timestamp                             # time unit nanoseconds
            end_time_unix_nano: timestamp                               # time unit nanoseconds
            trace_id: 16_bytes_binary_dictionary | 16_bytes_binary      # arrow fixed size binary array, 16_bytes_binary_dictionary by default, fallback to 16_bytes_binary when cardinality too high
            span_id: 8_bytes_binary_dictionary | 8_bytes_binary         # arrow fixed size binary array, 8_bytes_binary_dictionary by default, fallback to 8_bytes_binary when cardinality too high
            trace_state: string_dictionary | string                     # string_dictionary by default, fallback to string when cardinality too high
            parent_span_id: 8_bytes_binary_dictionary | 8_bytes_binary  # arrow fixed size binary array, 8_bytes_binary_dictionary by default, fallback to 8_bytes_binary when cardinality too high
            name: string_dictionary | string                            # string_dictionary by default, fallback to string when cardinality too high
            kind: int32_dictionary | int32                              # int32_dictionary by default, fallback to int32 when cardinality too high, OTLP enum with 6 variants
            attributes: *attributes                                     # arrow map
            dropped_attributes_count: uint32
            events:                                                     # arrow list of struct
              - time_unix_nano: timestamp                               # time unit nanoseconds
                name: string_dictionary | string                        # string_dictionary by default, fallback to string when cardinality too high
                attributes: *attributes                                 # arrow map
                dropped_attributes_count: uint32
            dropped_events_count: uint32
            links:                                                      # arrow list of struct
              - trace_id: 16_bytes_binary_dictionary | 16_bytes_binary  # arrow fixed size binary array, 16_bytes_binary_dictionary by default, fallback to 16_bytes_binary when cardinality too high
                span_id: 8_bytes_binary_dictionary | 8_bytes_binary     # arrow fixed size binary array, 8_bytes_binary_dictionary by default, fallback to 8_bytes_binary when cardinality too high
                trace_state: string_dictionary | string                 # string_dictionary by default, fallback to string when cardinality too high
                attributes: *attributes                                 # arrow map
                dropped_attributes_count: uint32
            dropped_links_count: uint32
            status: struct
              code: int32_dictionary | int32                            # int32_dictionary by default, fallback to int32 when cardinality too high, OTLP enum with 4 variants
              status_message: string_dictionary | string                # string_dictionary by default, fallback to string when cardinality too high
---

```