### PR TITLE
Add network bytes counters to the OTel-Arrow exporter/receiver components

### DIFF
--- a/collector/examples/bridge/edge-collector.yaml
+++ b/collector/examples/bridge/edge-collector.yaml
@@ -55,3 +55,4 @@ service:
   telemetry:
     metrics:
       address: 127.0.0.1:8888
+      level: normal

--- a/collector/examples/bridge/saas-collector.yaml
+++ b/collector/examples/bridge/saas-collector.yaml
@@ -52,3 +52,4 @@ service:
   telemetry:
     metrics:
       address: 127.0.0.1:8889
+      level: normal

--- a/collector/gen/exporter/otlpexporter/otlp.go
+++ b/collector/gen/exporter/otlpexporter/otlp.go
@@ -32,11 +32,12 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/f5/otel-arrow-adapter/collector/gen/exporter/otlpexporter/internal/arrow"
+	"github.com/f5/otel-arrow-adapter/collector/gen/internal/netstats"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	"github.com/f5/otel-arrow-adapter/collector/gen/exporter/otlpexporter/internal/arrow"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -57,6 +58,7 @@ type baseExporter struct {
 	metadata       metadata.MD
 	callOptions    []grpc.CallOption
 	settings       exporter.CreateSettings
+	netStats       *netstats.NetworkReporter
 
 	// Default user-agent header.
 	userAgent string
@@ -74,6 +76,10 @@ func newExporter(cfg component.Config, set exporter.CreateSettings) (*baseExport
 		return nil, errors.New("OTLP exporter config requires an Endpoint")
 	}
 
+	netStats, err := netstats.NewExporterNetworkReporter(set)
+	if err != nil {
+		return nil, err
+	}
 	userAgent := fmt.Sprintf("%s/%s (%s/%s)",
 		set.BuildInfo.Description, set.BuildInfo.Version, runtime.GOOS, runtime.GOARCH)
 
@@ -81,13 +87,19 @@ func newExporter(cfg component.Config, set exporter.CreateSettings) (*baseExport
 		userAgent += fmt.Sprintf(" ApacheArrow/%s (NumStreams/%d)", arrowPkg.PkgVersion, oCfg.Arrow.NumStreams)
 	}
 
-	return &baseExporter{config: oCfg, settings: set, userAgent: userAgent}, nil
+	return &baseExporter{config: oCfg, settings: set, userAgent: userAgent, netStats: netStats}, nil
 }
 
 // start actually creates the gRPC connection. The client construction is deferred till this point as this
 // is the only place we get hold of Extensions which are required to construct auth round tripper.
 func (e *baseExporter) start(ctx context.Context, host component.Host) (err error) {
-	if e.clientConn, err = e.config.GRPCClientSettings.ToClientConn(ctx, host, e.settings.TelemetrySettings, grpc.WithUserAgent(e.userAgent)); err != nil {
+	dialOpts := []grpc.DialOption{
+		grpc.WithUserAgent(e.userAgent),
+	}
+	if e.netStats != nil {
+		dialOpts = append(dialOpts, grpc.WithStatsHandler(e.netStats))
+	}
+	if e.clientConn, err = e.config.GRPCClientSettings.ToClientConn(ctx, host, e.settings.TelemetrySettings, dialOpts...); err != nil {
 		return err
 	}
 	e.traceExporter = ptraceotlp.NewGRPCClient(e.clientConn)

--- a/collector/gen/internal/netstats/handler.go
+++ b/collector/gen/internal/netstats/handler.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netstats
+
+import (
+	"context"
+
+	"google.golang.org/grpc/stats"
+)
+
+// TagRPC implements grpc/stats.Handler
+func (rep *NetworkReporter) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+// HandleRPC implements grpc/stats.Handler
+func (rep *NetworkReporter) HandleRPC(ctx context.Context, rs stats.RPCStats) {
+	switch s := rs.(type) {
+	case *stats.Begin, *stats.OutHeader, *stats.OutTrailer, *stats.InHeader, *stats.InTrailer:
+		// Note we have some info aboute header WireLength,
+		// but intentionally not counting.
+
+	case *stats.InPayload:
+		var ss SizesStruct
+		ss.Length = int64(s.Length)
+		ss.WireLength = int64(s.WireLength)
+		rep.CountReceive(ctx, ss)
+
+	case *stats.OutPayload:
+		var ss SizesStruct
+		ss.Length = int64(s.Length)
+		ss.WireLength = int64(s.WireLength)
+		rep.CountSend(ctx, ss)
+	}
+}
+
+// TagConn implements grpc/stats.Handler
+func (rep *NetworkReporter) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+// HandleConn implements grpc/stats.Handler
+func (rep *NetworkReporter) HandleConn(_ context.Context, s stats.ConnStats) {
+	// Note: ConnBegin and ConnEnd
+}

--- a/collector/gen/internal/netstats/netstats.go
+++ b/collector/gen/internal/netstats/netstats.go
@@ -1,0 +1,187 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netstats
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/instrument"
+	"go.uber.org/multierr"
+
+	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	// ExporterKey used to identify exporters in metrics and traces.
+	ExporterKey = "exporter"
+
+	// ReceiverKey used to identify receivers in metrics and traces.
+	ReceiverKey = "receiver"
+
+	// SentBytes is used to track bytes sent by exporters and receivers.
+	SentBytes = "sent"
+
+	// SentWireBytes is used to track bytes sent on the wire
+	// (includes compression) by exporters and receivers.
+	SentWireBytes = "sent_wire"
+
+	// RecvBytes is used to track bytes received by exporters and receivers.
+	RecvBytes = "recv"
+
+	// RecvWireBytes is used to track bytes received on the wire
+	// (includes compression) by exporters and receivers.
+	RecvWireBytes = "recv_wire"
+
+	scopeName = "github.com/f5/otel-arrow-adapter/collector/netstats"
+)
+
+// NetworkReporter is a helper to add network-level observability to
+// an exporter or receiver.
+type NetworkReporter struct {
+	attrs         []attribute.KeyValue
+	sentBytes     instrument.Int64Counter
+	sentWireBytes instrument.Int64Counter
+	recvBytes     instrument.Int64Counter
+	recvWireBytes instrument.Int64Counter
+}
+
+// SizesStruct is used to pass uncompressed on-wire message lengths to
+// the CountSend() and CountReceive() methods.
+type SizesStruct struct {
+	Length     int64
+	WireLength int64
+}
+
+const (
+	bytesUnit           = "bytes"
+	sentDescription     = "Number of bytes sent by the component."
+	sentWireDescription = "Number of bytes sent on the wire by the component."
+	recvDescription     = "Number of bytes received by the component."
+	recvWireDescription = "Number of bytes received on the wire by the component."
+)
+
+// makeSentMetrics builds the sent and sent-wire metric instruments
+// for an exporter or receiver using the corresponding `prefix`.
+func makeSentMetrics(prefix string, meter metric.Meter) (sent, sentWire instrument.Int64Counter, _ error) {
+	sentBytes, err1 := meter.Int64Counter(prefix+"_"+SentBytes, instrument.WithDescription(sentDescription), instrument.WithUnit(bytesUnit))
+	sentWireBytes, err2 := meter.Int64Counter(prefix+"_"+SentWireBytes, instrument.WithDescription(sentWireDescription), instrument.WithUnit(bytesUnit))
+	return sentBytes, sentWireBytes, multierr.Append(err1, err2)
+}
+
+// makeRecvMetrics builds the  and received-wire metric instruments
+// for an exporter or receiver using the corresponding `prefix`.
+func makeRecvMetrics(prefix string, meter metric.Meter) (recv, recvWire instrument.Int64Counter, _ error) {
+	recvBytes, err1 := meter.Int64Counter(prefix+"_"+RecvBytes, instrument.WithDescription(recvDescription), instrument.WithUnit(bytesUnit))
+	recvWireBytes, err2 := meter.Int64Counter(prefix+"_"+RecvWireBytes, instrument.WithDescription(recvWireDescription), instrument.WithUnit(bytesUnit))
+	return recvBytes, recvWireBytes, multierr.Append(err1, err2)
+}
+
+// NewExporterNetworkReporter creates a new NetworkReporter configured for an exporter.
+func NewExporterNetworkReporter(settings exporter.CreateSettings) (*NetworkReporter, error) {
+	level := settings.TelemetrySettings.MetricsLevel
+
+	if level <= configtelemetry.LevelBasic {
+		// Note: NetworkReporter implements nil a check.
+		return nil, nil
+	}
+
+	meter := settings.TelemetrySettings.MeterProvider.Meter(scopeName)
+	rep := &NetworkReporter{
+		attrs: []attribute.KeyValue{
+			attribute.String(ExporterKey, settings.ID.String()),
+		},
+	}
+
+	var errors, err error
+	rep.sentBytes, rep.sentWireBytes, err = makeSentMetrics(ExporterKey, meter)
+	errors = multierr.Append(errors, err)
+
+	// Normally, an exporter counts sent bytes, and skips received
+	// bytes.  LevelDetailed will reveal exporter-received bytes.
+	if level > configtelemetry.LevelNormal {
+		rep.recvBytes, rep.recvWireBytes, err = makeRecvMetrics(ExporterKey, meter)
+		errors = multierr.Append(errors, err)
+	}
+
+	return rep, errors
+}
+
+// NewReceiverNetworkReporter creates a new NetworkReporter configured for an exporter.
+func NewReceiverNetworkReporter(settings receiver.CreateSettings) (*NetworkReporter, error) {
+	level := settings.TelemetrySettings.MetricsLevel
+
+	if level <= configtelemetry.LevelBasic {
+		// Note: NetworkReporter implements nil a check.
+		return nil, nil
+	}
+
+	meter := settings.MeterProvider.Meter(scopeName)
+	rep := &NetworkReporter{
+		attrs: []attribute.KeyValue{
+			attribute.String(ReceiverKey, settings.ID.String()),
+		},
+	}
+
+	var errors, err error
+	rep.recvBytes, rep.recvWireBytes, err = makeRecvMetrics(ReceiverKey, meter)
+	errors = multierr.Append(errors, err)
+
+	// Normally, a receiver counts received bytes, and skips sent
+	// bytes.  LevelDetailed will reveal receiver-sent bytes.
+	if level > configtelemetry.LevelNormal {
+		rep.sentBytes, rep.sentWireBytes, err = makeSentMetrics(ReceiverKey, meter)
+		errors = multierr.Append(errors, err)
+	}
+
+	return rep, errors
+}
+
+// CountSend is used to report a message sent by the component.  For
+// exporters, SizesStruct indicates the size of a request.  For
+// receivers, SizesStruct indicates the size of a response.
+func (rep *NetworkReporter) CountSend(ctx context.Context, ss SizesStruct) {
+	// Indicates basic level telemetry, not counting bytes.
+	if rep == nil {
+		return
+	}
+
+	if rep.sentBytes != nil && ss.Length > 0 {
+		rep.sentBytes.Add(ctx, ss.Length, rep.attrs...)
+	}
+	if rep.sentWireBytes != nil && ss.WireLength > 0 {
+		rep.sentWireBytes.Add(ctx, ss.WireLength, rep.attrs...)
+	}
+}
+
+// CountReceive is used to report a message received by the component.  For
+// exporters, SizesStruct indicates the size of a response.  For
+// receivers, SizesStruct indicates the size of a request.
+func (rep *NetworkReporter) CountReceive(ctx context.Context, ss SizesStruct) {
+	// Indicates basic level telemetry, not counting bytes.
+	if rep == nil {
+		return
+	}
+
+	if rep.recvBytes != nil && ss.Length > 0 {
+		rep.recvBytes.Add(ctx, ss.Length, rep.attrs...)
+	}
+	if rep.recvWireBytes != nil && ss.WireLength > 0 {
+		rep.recvWireBytes.Add(ctx, ss.WireLength, rep.attrs...)
+	}
+}

--- a/collector/gen/internal/netstats/netstats_test.go
+++ b/collector/gen/internal/netstats/netstats_test.go
@@ -1,0 +1,149 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netstats
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+func metricValues(rm metricdata.ResourceMetrics) map[string]interface{} {
+	res := map[string]interface{}{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, mm := range sm.Metrics {
+			var value int64
+			for _, dp := range mm.Data.(metricdata.Sum[int64]).DataPoints {
+				value = dp.Value
+			}
+			res[mm.Name] = value
+		}
+	}
+	return res
+}
+
+func TestNetStatsExporterNone(t *testing.T) {
+	testNetStatsExporter(t, configtelemetry.LevelNone, map[string]interface{}{})
+}
+
+func TestNetStatsExporterNormal(t *testing.T) {
+	testNetStatsExporter(t, configtelemetry.LevelNormal, map[string]interface{}{
+		"exporter_sent":      int64(1000),
+		"exporter_sent_wire": int64(100),
+	})
+}
+
+func TestNetStatsExporterDetailed(t *testing.T) {
+	testNetStatsExporter(t, configtelemetry.LevelDetailed, map[string]interface{}{
+		"exporter_sent":      int64(1000),
+		"exporter_sent_wire": int64(100),
+		"exporter_recv":      int64(100),
+		"exporter_recv_wire": int64(10),
+	})
+}
+
+func testNetStatsExporter(t *testing.T, level configtelemetry.Level, expect map[string]interface{}) {
+
+	rdr := metric.NewManualReader()
+	mp := metric.NewMeterProvider(
+		metric.WithResource(resource.Empty()),
+		metric.WithReader(rdr),
+	)
+	enr, err := NewExporterNetworkReporter(exporter.CreateSettings{
+		ID: component.NewID("test"),
+		TelemetrySettings: component.TelemetrySettings{
+			MeterProvider: mp,
+			MetricsLevel:  level,
+		},
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		enr.CountSend(ctx, SizesStruct{
+			Length:     100,
+			WireLength: 10,
+		})
+		enr.CountReceive(ctx, SizesStruct{
+			Length:     10,
+			WireLength: 1,
+		})
+	}
+	rm, err := rdr.Collect(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, expect, metricValues(rm))
+}
+
+func TestNetStatsReceiverNone(t *testing.T) {
+	testNetStatsReceiver(t, configtelemetry.LevelNone, map[string]interface{}{})
+}
+
+func TestNetStatsReceiverNormal(t *testing.T) {
+	testNetStatsReceiver(t, configtelemetry.LevelNormal, map[string]interface{}{
+		"receiver_recv":      int64(1000),
+		"receiver_recv_wire": int64(100),
+	})
+}
+
+func TestNetStatsReceiverDetailed(t *testing.T) {
+	testNetStatsReceiver(t, configtelemetry.LevelDetailed, map[string]interface{}{
+		"receiver_recv":      int64(1000),
+		"receiver_recv_wire": int64(100),
+		"receiver_sent":      int64(100),
+		"receiver_sent_wire": int64(10),
+	})
+}
+
+func testNetStatsReceiver(t *testing.T, level configtelemetry.Level, expect map[string]interface{}) {
+
+	rdr := metric.NewManualReader()
+	mp := metric.NewMeterProvider(
+		metric.WithResource(resource.Empty()),
+		metric.WithReader(rdr),
+	)
+	enr, err := NewReceiverNetworkReporter(receiver.CreateSettings{
+		ID: component.NewID("test"),
+		TelemetrySettings: component.TelemetrySettings{
+			MeterProvider: mp,
+			MetricsLevel:  level,
+		},
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		enr.CountReceive(ctx, SizesStruct{
+			Length:     100,
+			WireLength: 10,
+		})
+		enr.CountSend(ctx, SizesStruct{
+			Length:     10,
+			WireLength: 1,
+		})
+	}
+	rm, err := rdr.Collect(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, expect, metricValues(rm))
+}


### PR DESCRIPTION
Part of #119.

Solution and problem addressed are described in https://github.com/open-telemetry/opentelemetry-collector/issues/6638.