### PR TITLE
Add error package to manage structured/nested errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ for metrics, logs, and traces (in this order).
 
 ![img](docs/img/logs_compression_rate_benchmark.png)
 
-![img](docs/img/traces_compression_rate_benchmark.pnggo run)
+![img](docs/img/traces_compression_rate_benchmark.png)
 
 ### End-to-end performance benchmarks
 

--- a/pkg/arrow/errors.go
+++ b/pkg/arrow/errors.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package arrow
+
+import "errors"
+
+var (
+	// ErrInvalidArrayType is returned when an array is not of the expected type.
+	ErrInvalidArrayType = errors.New("invalid arrow array type")
+
+	// ErrNotStructType is returned when an array is not of type Struct.
+	ErrNotStructType = errors.New("not arrow.StructType")
+	// ErrNotListOfStructsType is returned when an array is not of type List of structs.
+	ErrNotListOfStructsType = errors.New("not arrow.ListType of arrow.StructType")
+	// ErrNotListType is returned when an array is not of type list.
+	ErrNotListType = errors.New("not an arrow.ListType")
+
+	// ErrNotArrayStruct is returned when an array is not an array.Struct.
+	ErrNotArrayStruct = errors.New("not an arrow array.Struct")
+	// ErrNotArrayList is returned when an array is not an array.List.
+	ErrNotArrayList = errors.New("not an arrow array.List")
+	// ErrNotArrayListOfStructs is returned when an array is not an array.List of array.Struct.
+	ErrNotArrayListOfStructs = errors.New("not an Arrow array.List of array.Struct")
+
+	// ErrDuplicateFieldName is returned when a field name is duplicated in the same struct.
+	ErrDuplicateFieldName = errors.New("duplicate field name")
+)

--- a/pkg/arrow/from_array.go
+++ b/pkg/arrow/from_array.go
@@ -20,10 +20,16 @@ package arrow
 // Utility functions to extract values from Arrow arrays.
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
+
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
+)
+
+var (
+	ErrInvalidColumnType = errors.New("invalid column type")
 )
 
 // I32FromArray returns the int32 value for a specific row in an Arrow array.
@@ -46,7 +52,7 @@ func I32FromArray(arr arrow.Array, row int) (int32, error) {
 				return i32Arr.Value(arr.GetValueIndex(row)), nil
 			}
 		default:
-			return 0, fmt.Errorf("column is not of type int32")
+			return 0, werror.WrapWithMsg(ErrInvalidColumnType, "not an int32 array")
 		}
 	}
 }
@@ -64,7 +70,7 @@ func I64FromArray(arr arrow.Array, row int) (int64, error) {
 				return arr.Value(row), nil
 			}
 		default:
-			return 0, fmt.Errorf("column is not of type int64")
+			return 0, werror.WrapWithMsg(ErrInvalidColumnType, "not an int64 array")
 		}
 	}
 }
@@ -84,7 +90,7 @@ func StringFromArray(arr arrow.Array, row int) (string, error) {
 		case *array.Dictionary:
 			return arr.Dictionary().(*array.String).Value(arr.GetValueIndex(row)), nil
 		default:
-			return "", fmt.Errorf("column is not of type string")
+			return "", werror.WrapWithMsg(ErrInvalidColumnType, "not a string array")
 		}
 	}
 }
@@ -104,7 +110,7 @@ func BinaryFromArray(arr arrow.Array, row int) ([]byte, error) {
 		case *array.Dictionary:
 			return arr.Dictionary().(*array.Binary).Value(arr.GetValueIndex(row)), nil
 		default:
-			return nil, fmt.Errorf("column is not of type binary")
+			return nil, werror.WrapWithMsg(ErrInvalidColumnType, "not a binary array")
 		}
 	}
 }
@@ -124,7 +130,7 @@ func FixedSizeBinaryFromArray(arr arrow.Array, row int) ([]byte, error) {
 		case *array.Dictionary:
 			return arr.Dictionary().(*array.FixedSizeBinary).Value(arr.GetValueIndex(row)), nil
 		default:
-			return nil, fmt.Errorf("column is not of type binary")
+			return nil, werror.WrapWithMsg(ErrInvalidColumnType, "not a fixed size binary array")
 		}
 	}
 }
@@ -142,7 +148,7 @@ func BoolFromArray(arr arrow.Array, row int) (bool, error) {
 				return arr.Value(row), nil
 			}
 		default:
-			return false, fmt.Errorf("column is not of type bool")
+			return false, werror.WrapWithMsg(ErrInvalidColumnType, "not a bool array")
 		}
 	}
 }
@@ -160,7 +166,7 @@ func F64FromArray(arr arrow.Array, row int) (float64, error) {
 				return arr.Value(row), nil
 			}
 		default:
-			return 0.0, fmt.Errorf("column is not of type f64")
+			return 0.0, werror.WrapWithMsg(ErrInvalidColumnType, "not a float64 array")
 		}
 	}
 }
@@ -179,7 +185,7 @@ func F64OrNilFromArray(arr arrow.Array, row int) (*float64, error) {
 				return &v, nil
 			}
 		default:
-			return nil, fmt.Errorf("column is not of type f64")
+			return nil, werror.WrapWithMsg(ErrInvalidColumnType, "not a float64 array")
 		}
 	}
 }
@@ -197,7 +203,7 @@ func U64FromArray(arr arrow.Array, row int) (uint64, error) {
 				return arr.Value(row), nil
 			}
 		default:
-			return 0, fmt.Errorf("column is not of type uint64")
+			return 0, werror.WrapWithMsg(ErrInvalidColumnType, "not a uint64 array")
 		}
 	}
 }
@@ -215,7 +221,7 @@ func TimestampFromArray(arr arrow.Array, row int) (arrow.Timestamp, error) {
 				return arr.Value(row), nil
 			}
 		default:
-			return 0, fmt.Errorf("column is not of type timestamp")
+			return 0, werror.WrapWithMsg(ErrInvalidColumnType, "not a timestamp array")
 		}
 	}
 }
@@ -233,7 +239,7 @@ func U32FromArray(arr arrow.Array, row int) (uint32, error) {
 				return arr.Value(row), nil
 			}
 		default:
-			return 0, fmt.Errorf("column is not of type uint32")
+			return 0, werror.WrapWithMsg(ErrInvalidColumnType, "not a uint32 array")
 		}
 	}
 }

--- a/pkg/arrow/from_array.go
+++ b/pkg/arrow/from_array.go
@@ -20,16 +20,10 @@ package arrow
 // Utility functions to extract values from Arrow arrays.
 
 import (
-	"errors"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 
 	"github.com/f5/otel-arrow-adapter/pkg/werror"
-)
-
-var (
-	ErrInvalidColumnType = errors.New("invalid column type")
 )
 
 // I32FromArray returns the int32 value for a specific row in an Arrow array.
@@ -52,7 +46,7 @@ func I32FromArray(arr arrow.Array, row int) (int32, error) {
 				return i32Arr.Value(arr.GetValueIndex(row)), nil
 			}
 		default:
-			return 0, werror.WrapWithMsg(ErrInvalidColumnType, "not an int32 array")
+			return 0, werror.WrapWithMsg(ErrInvalidArrayType, "not an int32 array")
 		}
 	}
 }
@@ -70,7 +64,7 @@ func I64FromArray(arr arrow.Array, row int) (int64, error) {
 				return arr.Value(row), nil
 			}
 		default:
-			return 0, werror.WrapWithMsg(ErrInvalidColumnType, "not an int64 array")
+			return 0, werror.WrapWithMsg(ErrInvalidArrayType, "not an int64 array")
 		}
 	}
 }
@@ -90,7 +84,7 @@ func StringFromArray(arr arrow.Array, row int) (string, error) {
 		case *array.Dictionary:
 			return arr.Dictionary().(*array.String).Value(arr.GetValueIndex(row)), nil
 		default:
-			return "", werror.WrapWithMsg(ErrInvalidColumnType, "not a string array")
+			return "", werror.WrapWithMsg(ErrInvalidArrayType, "not a string array")
 		}
 	}
 }
@@ -110,7 +104,7 @@ func BinaryFromArray(arr arrow.Array, row int) ([]byte, error) {
 		case *array.Dictionary:
 			return arr.Dictionary().(*array.Binary).Value(arr.GetValueIndex(row)), nil
 		default:
-			return nil, werror.WrapWithMsg(ErrInvalidColumnType, "not a binary array")
+			return nil, werror.WrapWithMsg(ErrInvalidArrayType, "not a binary array")
 		}
 	}
 }
@@ -130,7 +124,7 @@ func FixedSizeBinaryFromArray(arr arrow.Array, row int) ([]byte, error) {
 		case *array.Dictionary:
 			return arr.Dictionary().(*array.FixedSizeBinary).Value(arr.GetValueIndex(row)), nil
 		default:
-			return nil, werror.WrapWithMsg(ErrInvalidColumnType, "not a fixed size binary array")
+			return nil, werror.WrapWithMsg(ErrInvalidArrayType, "not a fixed size binary array")
 		}
 	}
 }
@@ -148,7 +142,7 @@ func BoolFromArray(arr arrow.Array, row int) (bool, error) {
 				return arr.Value(row), nil
 			}
 		default:
-			return false, werror.WrapWithMsg(ErrInvalidColumnType, "not a bool array")
+			return false, werror.WrapWithMsg(ErrInvalidArrayType, "not a bool array")
 		}
 	}
 }
@@ -166,7 +160,7 @@ func F64FromArray(arr arrow.Array, row int) (float64, error) {
 				return arr.Value(row), nil
 			}
 		default:
-			return 0.0, werror.WrapWithMsg(ErrInvalidColumnType, "not a float64 array")
+			return 0.0, werror.WrapWithMsg(ErrInvalidArrayType, "not a float64 array")
 		}
 	}
 }
@@ -185,7 +179,7 @@ func F64OrNilFromArray(arr arrow.Array, row int) (*float64, error) {
 				return &v, nil
 			}
 		default:
-			return nil, werror.WrapWithMsg(ErrInvalidColumnType, "not a float64 array")
+			return nil, werror.WrapWithMsg(ErrInvalidArrayType, "not a float64 array")
 		}
 	}
 }
@@ -203,7 +197,7 @@ func U64FromArray(arr arrow.Array, row int) (uint64, error) {
 				return arr.Value(row), nil
 			}
 		default:
-			return 0, werror.WrapWithMsg(ErrInvalidColumnType, "not a uint64 array")
+			return 0, werror.WrapWithMsg(ErrInvalidArrayType, "not a uint64 array")
 		}
 	}
 }
@@ -221,7 +215,7 @@ func TimestampFromArray(arr arrow.Array, row int) (arrow.Timestamp, error) {
 				return arr.Value(row), nil
 			}
 		default:
-			return 0, werror.WrapWithMsg(ErrInvalidColumnType, "not a timestamp array")
+			return 0, werror.WrapWithMsg(ErrInvalidArrayType, "not a timestamp array")
 		}
 	}
 }
@@ -239,7 +233,7 @@ func U32FromArray(arr arrow.Array, row int) (uint32, error) {
 				return arr.Value(row), nil
 			}
 		default:
-			return 0, werror.WrapWithMsg(ErrInvalidColumnType, "not a uint32 array")
+			return 0, werror.WrapWithMsg(ErrInvalidArrayType, "not a uint32 array")
 		}
 	}
 }

--- a/pkg/arrow/from_schema.go
+++ b/pkg/arrow/from_schema.go
@@ -20,17 +20,9 @@ package arrow
 // Utility functions to extract ids from Arrow schemas.
 
 import (
-	"errors"
-
 	"github.com/apache/arrow/go/v11/arrow"
 
 	"github.com/f5/otel-arrow-adapter/pkg/werror"
-)
-
-var (
-	ErrDuplicateFieldName = errors.New("duplicate field name")
-	ErrNotListOfStruct    = errors.New("not a list of structs")
-	ErrNotList            = errors.New("not a list")
 )
 
 // ListOfStructsFieldIDFromSchema returns the field id of a list of structs
@@ -49,10 +41,10 @@ func ListOfStructsFieldIDFromSchema(schema *arrow.Schema, fieldName string) (int
 	if lt, ok := schema.Field(ids[0]).Type.(*arrow.ListType); ok {
 		st, ok := lt.ElemField().Type.(*arrow.StructType)
 		if !ok {
-			return 0, nil, werror.WrapWithContext(ErrNotListOfStruct, map[string]interface{}{"fieldName": fieldName})
+			return 0, nil, werror.WrapWithContext(ErrNotArrayListOfStructs, map[string]interface{}{"fieldName": fieldName})
 		}
 		return ids[0], st, nil
 	} else {
-		return 0, nil, werror.WrapWithContext(ErrNotList, map[string]interface{}{"fieldName": fieldName})
+		return 0, nil, werror.WrapWithContext(ErrNotArrayList, map[string]interface{}{"fieldName": fieldName})
 	}
 }

--- a/pkg/arrow/from_struct.go
+++ b/pkg/arrow/from_struct.go
@@ -21,20 +21,10 @@ package arrow
 // Arrow arrays.
 
 import (
-	"errors"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 
 	"github.com/f5/otel-arrow-adapter/pkg/werror"
-)
-
-var (
-	ErrNotArrayStruct       = errors.New("not an arrow array of structs")
-	ErrNotStructType        = errors.New("not an arrow struct type")
-	ErrNotListOfStructsType = errors.New("not an arrow list of structs type")
-	ErrNotListType          = errors.New("not an arrow list type")
-	ErrNotArrayList         = errors.New("not an arrow array list")
 )
 
 // U32FromStruct returns the uint32 value for a specific row in an Arrow struct

--- a/pkg/arrow/from_struct.go
+++ b/pkg/arrow/from_struct.go
@@ -21,10 +21,17 @@ package arrow
 // Arrow arrays.
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
+
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
+)
+
+var (
+	ErrNotArrayStruct = errors.New("not an arrow array of structs")
 )
 
 // U32FromStruct returns the uint32 value for a specific row in an Arrow struct
@@ -126,7 +133,10 @@ func I32FromStruct(arr arrow.Array, row int, id int) (int32, error) {
 	if structArr != nil {
 		return I32FromArray(structArr.Field(id), row)
 	} else {
-		return 0, fmt.Errorf("column array is not of type struct")
+		return 0, werror.WrapWithContext(ErrNotArrayStruct, map[string]interface{}{
+			"row": row,
+			"id":  id,
+		})
 	}
 }
 

--- a/pkg/arrow/list_structs.go
+++ b/pkg/arrow/list_structs.go
@@ -20,18 +20,13 @@ package arrow
 // Wrapper around an Arrow list of structs used to expose utility functions.
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-)
 
-var (
-	errNotArrayStruct        = errors.New("Not an Arrow array.Struct")
-	errNotArrayList          = errors.New("Not an Arrow array.List")
-	errNotArrayListOfStructs = errors.New("Not an Arrow array.List of array.Struct")
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 // ListOfStructs is a wrapper around an Arrow list of structs used to expose utility functions.
@@ -67,10 +62,10 @@ func ListOfStructsFromRecord(record arrow.Record, fieldID int, row int) (*ListOf
 				end:   end,
 			}, nil
 		default:
-			return nil, fmt.Errorf("ListOfStructsFromRecord(fieldID=%d)->%w", fieldID, errNotArrayListOfStructs)
+			return nil, werror.WrapWithContext(ErrNotArrayListOfStructs, map[string]interface{}{"fieldID": fieldID, "row": row})
 		}
 	default:
-		return nil, fmt.Errorf("ListOfStructsFromRecord(fieldID=%d)->%w", fieldID, errNotArrayList)
+		return nil, werror.WrapWithContext(ErrNotArrayList, map[string]interface{}{"fieldID": fieldID, "row": row})
 	}
 }
 
@@ -85,7 +80,7 @@ func ListOfStructsFromArray(arr arrow.Array, row int) (*ListOfStructs, error) {
 		case *array.Struct:
 			dt, ok := structArr.DataType().(*arrow.StructType)
 			if !ok {
-				return nil, fmt.Errorf("ListOfStructsFromArray->%w", errNotArrayListOfStructs)
+				return nil, werror.WrapWithContext(ErrNotArrayListOfStructs, map[string]interface{}{"row": row})
 			}
 			start := int(listArr.Offsets()[row])
 			end := int(listArr.Offsets()[row+1])
@@ -97,10 +92,10 @@ func ListOfStructsFromArray(arr arrow.Array, row int) (*ListOfStructs, error) {
 				end:   end,
 			}, nil
 		default:
-			return nil, fmt.Errorf("ListOfStructsFromArray->%w", errNotArrayListOfStructs)
+			return nil, werror.WrapWithContext(ErrNotArrayListOfStructs, map[string]interface{}{"row": row})
 		}
 	default:
-		return nil, fmt.Errorf("ListOfStructsFromArray->%w", errNotArrayList)
+		return nil, werror.WrapWithContext(ErrNotArrayList, map[string]interface{}{"row": row})
 	}
 }
 
@@ -362,7 +357,7 @@ func (los *ListOfStructs) StructArray(name string, row int) (*arrow.StructType, 
 		}
 		return structArr.DataType().(*arrow.StructType), structArr, nil
 	default:
-		return nil, nil, fmt.Errorf("StructArray(name=%q)->%w", name, errNotArrayStruct)
+		return nil, nil, werror.WrapWithContext(ErrNotArrayStruct, map[string]interface{}{"fieldName": name, "row": row})
 	}
 }
 
@@ -379,7 +374,7 @@ func (los *ListOfStructs) StructByID(fieldID int, row int) (*arrow.StructType, *
 		}
 		return structArr.DataType().(*arrow.StructType), structArr, nil
 	default:
-		return nil, nil, fmt.Errorf("StructByID(fieldID=%d)->%w", fieldID, errNotArrayStruct)
+		return nil, nil, werror.WrapWithContext(ErrNotArrayStruct, map[string]interface{}{"fieldID": fieldID, "row": row})
 	}
 }
 
@@ -403,7 +398,7 @@ func (los *ListOfStructs) ListValuesById(row int, fieldID int) (arr arrow.Array,
 		end = int(listArr.Offsets()[row+1])
 		arr = listArr.ListValues()
 	default:
-		err = fmt.Errorf("ListValuesById(fieldID=%d)->%w", fieldID, errNotArrayList)
+		err = werror.WrapWithContext(ErrNotArrayList, map[string]interface{}{"fieldID": fieldID, "row": row})
 	}
 	return
 }
@@ -424,7 +419,7 @@ func (los *ListOfStructs) ListOfStructsById(row int, fieldID int) (*ListOfStruct
 		case *array.Struct:
 			dt, ok := structArr.DataType().(*arrow.StructType)
 			if !ok {
-				return nil, fmt.Errorf("ListOfStructsById(fieldID=%d)->%w", fieldID, errNotArrayStruct)
+				return nil, werror.WrapWithContext(ErrNotArrayStruct, map[string]interface{}{"fieldID": fieldID, "row": row})
 			}
 			start := int(listArr.Offsets()[row])
 			end := int(listArr.Offsets()[row+1])
@@ -436,10 +431,10 @@ func (los *ListOfStructs) ListOfStructsById(row int, fieldID int) (*ListOfStruct
 				end:   end,
 			}, nil
 		default:
-			return nil, fmt.Errorf("ListOfStructsById(fieldID=%d)->%w", fieldID, errNotArrayListOfStructs)
+			return nil, werror.WrapWithContext(ErrNotArrayListOfStructs, map[string]interface{}{"fieldID": fieldID, "row": row})
 		}
 	default:
-		return nil, fmt.Errorf("ListOfStructsById(fieldID=%d)->%w", fieldID, errNotArrayList)
+		return nil, werror.WrapWithContext(ErrNotArrayList, map[string]interface{}{"fieldID": fieldID, "row": row})
 	}
 }
 

--- a/pkg/arrow/list_structs.go
+++ b/pkg/arrow/list_structs.go
@@ -20,8 +20,6 @@ package arrow
 // Wrapper around an Arrow list of structs used to expose utility functions.
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -50,7 +48,7 @@ func ListOfStructsFromRecord(record arrow.Record, fieldID int, row int) (*ListOf
 		case *array.Struct:
 			dt, ok := structArr.DataType().(*arrow.StructType)
 			if !ok {
-				return nil, fmt.Errorf("field id %d is not a list of structs", fieldID)
+				return nil, werror.WrapWithContext(ErrNotArrayListOfStructs, map[string]interface{}{"fieldID": fieldID, "row": row})
 			}
 			start := int(listArr.Offsets()[row])
 			end := int(listArr.Offsets()[row+1])

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package error
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// Wrapper wraps an error with the file, line, and function where the error
+// was wrapped and an optional context map.
+type Wrapper struct {
+	// The wrapped error.
+	err error
+
+	// The file, line, and function where the error was wrapped.
+	file     string
+	line     int
+	function string
+
+	// An optional context map.
+	context map[string]interface{}
+}
+
+// Error returns the wrapped error's message.
+func (w Wrapper) Error() string {
+	var msg strings.Builder
+
+	msg.WriteString(w.function)
+	msg.WriteString(":")
+	msg.WriteString(strconv.Itoa(w.line))
+
+	if w.context != nil {
+		msg.WriteString("{")
+		for k, v := range w.context {
+			msg.WriteString(k)
+			msg.WriteString("=")
+			msg.WriteString(fmt.Sprintf("%v", v))
+		}
+		msg.WriteString("}")
+	}
+
+	if w.err != nil {
+		msg.WriteString("->")
+		msg.WriteString(w.err.Error())
+	}
+
+	return msg.String()
+}
+
+// Unwrap returns the wrapped error.
+func (w Wrapper) Unwrap() error {
+	return w.err
+}
+
+// File returns the file where the error was wrapped.
+func (w Wrapper) File() string {
+	return w.file
+}
+
+// Line returns the line where the error was wrapped.
+func (w Wrapper) Line() int {
+	return w.line
+}
+
+// Function returns the function where the error was wrapped.
+func (w Wrapper) Function() string {
+	return w.function
+}
+
+// Wrap wraps the given error with the current file, line, and function.
+func Wrap(err error) error {
+	return WrapWithContext(err, nil)
+}
+
+// WrapWithContext wraps the given error with the current file, line, function,
+// and the given context.
+func WrapWithContext(err error, context map[string]interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	pc, file, line, _ := runtime.Caller(1)
+	fn := runtime.FuncForPC(pc)
+
+	return Wrapper{
+		err:      err,
+		file:     file,
+		line:     line,
+		function: fn.Name(),
+		context:  context,
+	}
+}

--- a/pkg/otel/arrow_record/consumer.go
+++ b/pkg/otel/arrow_record/consumer.go
@@ -28,6 +28,7 @@ import (
 	logsotlp "github.com/f5/otel-arrow-adapter/pkg/otel/logs/otlp"
 	metricsotlp "github.com/f5/otel-arrow-adapter/pkg/otel/metrics/otlp"
 	tracesotlp "github.com/f5/otel-arrow-adapter/pkg/otel/traces/otlp"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 // This file implements a generic consumer API used to decode BatchArrowRecords messages into
@@ -72,7 +73,7 @@ func NewConsumer() *Consumer {
 func (c *Consumer) MetricsFrom(bar *colarspb.BatchArrowRecords) ([]pmetric.Metrics, error) {
 	records, err := c.Consume(bar)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	record2Metrics := func(record *RecordMessage) (pmetric.Metrics, error) {
@@ -84,7 +85,7 @@ func (c *Consumer) MetricsFrom(bar *colarspb.BatchArrowRecords) ([]pmetric.Metri
 	for _, record := range records {
 		metrics, err := record2Metrics(record)
 		if err != nil {
-			return nil, err
+			return nil, werror.Wrap(err)
 		}
 		result = append(result, metrics)
 	}
@@ -95,7 +96,7 @@ func (c *Consumer) MetricsFrom(bar *colarspb.BatchArrowRecords) ([]pmetric.Metri
 func (c *Consumer) LogsFrom(bar *colarspb.BatchArrowRecords) ([]plog.Logs, error) {
 	records, err := c.Consume(bar)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	record2Logs := func(record *RecordMessage) (plog.Logs, error) {
@@ -107,7 +108,7 @@ func (c *Consumer) LogsFrom(bar *colarspb.BatchArrowRecords) ([]plog.Logs, error
 	for _, record := range records {
 		logs, err := record2Logs(record)
 		if err != nil {
-			return nil, err
+			return nil, werror.Wrap(err)
 		}
 		result = append(result, logs)
 	}
@@ -118,7 +119,7 @@ func (c *Consumer) LogsFrom(bar *colarspb.BatchArrowRecords) ([]plog.Logs, error
 func (c *Consumer) TracesFrom(bar *colarspb.BatchArrowRecords) ([]ptrace.Traces, error) {
 	records, err := c.Consume(bar)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	record2Traces := func(record *RecordMessage) (ptrace.Traces, error) {
@@ -130,7 +131,7 @@ func (c *Consumer) TracesFrom(bar *colarspb.BatchArrowRecords) ([]ptrace.Traces,
 	for _, record := range records {
 		traces, err := record2Traces(record)
 		if err != nil {
-			return nil, err
+			return nil, werror.Wrap(err)
 		}
 		result = append(result, traces)
 	}
@@ -163,7 +164,7 @@ func (c *Consumer) Consume(bar *colarspb.BatchArrowRecords) ([]*RecordMessage, e
 				ipc.WithZstd(),
 			)
 			if err != nil {
-				return nil, err
+				return nil, werror.Wrap(err)
 			}
 			sc.ipcReader = ipcReader
 		}

--- a/pkg/otel/common/arrow/any_value.go
+++ b/pkg/otel/common/arrow/any_value.go
@@ -27,6 +27,7 @@ import (
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/builder"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 // Constants used to identify the type of value in the union.
@@ -126,7 +127,7 @@ func AnyValueBuilderFrom(av *builder.SparseUnionBuilder) *AnyValueBuilder {
 // memory allocated by the array.
 func (b *AnyValueBuilder) Build() (*array.SparseUnion, error) {
 	if b.released {
-		return nil, fmt.Errorf("any value builder already released")
+		return nil, werror.Wrap(ErrBuilderAlreadyReleased)
 	}
 
 	defer b.Release()
@@ -136,7 +137,7 @@ func (b *AnyValueBuilder) Build() (*array.SparseUnion, error) {
 // Append appends a new any value to the builder.
 func (b *AnyValueBuilder) Append(av pcommon.Value) error {
 	if b.released {
-		return fmt.Errorf("any value builder already released")
+		return werror.Wrap(ErrBuilderAlreadyReleased)
 	}
 
 	var err error
@@ -167,7 +168,7 @@ func (b *AnyValueBuilder) Append(av pcommon.Value) error {
 		err = b.appendCbor(cborData)
 	}
 
-	return err
+	return werror.Wrap(err)
 }
 
 // Release releases the memory allocated by the builder.

--- a/pkg/otel/common/arrow/errors.go
+++ b/pkg/otel/common/arrow/errors.go
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package arrow
+
+import "errors"
+
+var (
+	ErrBuilderAlreadyReleased = errors.New("builder already released")
+)

--- a/pkg/otel/common/arrow_test/schema_test.go
+++ b/pkg/otel/common/arrow_test/schema_test.go
@@ -29,6 +29,7 @@ import (
 	acommon "github.com/f5/otel-arrow-adapter/pkg/otel/common/schema"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/builder"
 	config "github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/config"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 const (
@@ -908,7 +909,7 @@ func (b *RootBuilder) Append(data *RootData) error {
 		b.i32.AppendNonZero(data.i32)
 		b.string.AppendNonEmpty(data.string)
 		if err := b.values.Append(data.values); err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		b.fixedSize8.Append(data.fixedSize8[:])
 		b.fixedSize16.Append(data.fixedSize16[:])

--- a/pkg/otel/common/cbor.go
+++ b/pkg/otel/common/cbor.go
@@ -19,12 +19,12 @@ package common
 
 import (
 	"bytes"
-	"errors"
-	"fmt"
 	"math"
 
 	"github.com/fxamacker/cbor/v2"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 // The CBOR representation is used to serialize complex pcommon.Value types (e.g. maps and slices) in the attributes
@@ -38,23 +38,17 @@ import (
 // small code size, fairly small message size, and extensibility without the need for version negotiation. CBOR is
 // defined in RFC 8949.
 
-var (
-	errInvalidKeyMap         = errors.New("invalid key map")
-	errUnsupportedCborType   = errors.New("unsupported cbor type")
-	errInvalidTypeConversion = errors.New("invalid type conversion")
-)
-
 // Serialize serializes the given pcommon.value into a CBOR byte array.
 func Serialize(v pcommon.Value) ([]byte, error) {
 	var buf bytes.Buffer
 
 	em, err := cbor.EncOptions{Sort: cbor.SortCanonical}.EncMode()
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	if err = encode(em.NewEncoder(&buf), v); err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	return buf.Bytes(), nil
@@ -66,11 +60,11 @@ func Deserialize(cborData []byte, target pcommon.Value) error {
 
 	var v interface{}
 	if err := dec.Decode(&v); err != nil {
-		return err
+		return werror.Wrap(err)
 	}
 
 	if err := decode(v, target); err != nil {
-		return err
+		return werror.Wrap(err)
 	}
 	return nil
 }
@@ -112,7 +106,7 @@ func encode(enc *cbor.Encoder, v pcommon.Value) (err error) {
 		slice := v.Slice()
 		for i := 0; i < slice.Len(); i++ {
 			if err := encode(enc, slice.At(i)); err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 		}
 
@@ -127,6 +121,8 @@ func encode(enc *cbor.Encoder, v pcommon.Value) (err error) {
 	case pcommon.ValueTypeEmpty:
 		err = enc.Encode(nil)
 	}
+
+	err = werror.Wrap(err)
 	return
 }
 
@@ -140,7 +136,7 @@ func decode(inVal interface{}, outVal pcommon.Value) error {
 		outVal.SetInt(typedV)
 	case uint64:
 		if typedV > math.MaxInt64 {
-			return fmt.Errorf("uint64 too large to be converted into an int64: %w", errInvalidTypeConversion)
+			return werror.Wrap(ErrInvalidTypeConversion)
 		}
 		outVal.SetInt(int64(typedV))
 	case float64:
@@ -156,7 +152,7 @@ func decode(inVal interface{}, outVal pcommon.Value) error {
 					return err
 				}
 			} else {
-				return fmt.Errorf("key map is not a string: %w", errInvalidKeyMap)
+				return werror.WrapWithContext(ErrInvalidKeyMap, map[string]interface{}{"key": k, "value": v})
 			}
 		}
 	case []interface{}:
@@ -173,7 +169,7 @@ func decode(inVal interface{}, outVal pcommon.Value) error {
 	case nil:
 		// nothing to do
 	default:
-		return fmt.Errorf("unsupported CBOR type=%T: %w", inVal, errUnsupportedCborType)
+		return werror.WrapWithContext(ErrUnsupportedCborType, map[string]interface{}{"type": inVal})
 	}
 	return nil
 }

--- a/pkg/otel/common/cbor.go
+++ b/pkg/otel/common/cbor.go
@@ -149,7 +149,7 @@ func decode(inVal interface{}, outVal pcommon.Value) error {
 		for k, v := range typedV {
 			if kStr, ok := k.(string); ok {
 				if err := decode(v, mapV.PutEmpty(kStr)); err != nil {
-					return err
+					return werror.Wrap(err)
 				}
 			} else {
 				return werror.WrapWithContext(ErrInvalidKeyMap, map[string]interface{}{"key": k, "value": v})
@@ -160,7 +160,7 @@ func decode(inVal interface{}, outVal pcommon.Value) error {
 		slice.EnsureCapacity(len(typedV))
 		for _, v := range typedV {
 			if err := decode(v, slice.AppendEmpty()); err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 		}
 	case []byte:

--- a/pkg/otel/common/errors.go
+++ b/pkg/otel/common/errors.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package common
+
+import "errors"
+
+var (
+	ErrInvalidKeyMap         = errors.New("invalid key map")
+	ErrUnsupportedCborType   = errors.New("unsupported cbor type")
+	ErrInvalidTypeConversion = errors.New("invalid type conversion")
+)

--- a/pkg/otel/common/otlp/errors.go
+++ b/pkg/otel/common/otlp/errors.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package otlp
+
+import "errors"
+
+var (
+	ErrInvalidTypeCode     = errors.New("invalid type code")
+	ErrInvalidFieldId      = errors.New("invalid field id")
+	ErrNotArrayMap         = errors.New("not an arrow array.Map")
+	ErrNotArraySparseUnion = errors.New("not an arrow array.SparseUnion")
+)

--- a/pkg/otel/common/otlp/resource.go
+++ b/pkg/otel/common/otlp/resource.go
@@ -15,13 +15,12 @@
 package otlp
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type ResourceIds struct {
@@ -33,12 +32,12 @@ type ResourceIds struct {
 func NewResourceIds(resSpansDT *arrow.StructType) (*ResourceIds, error) {
 	resId, resDT, err := arrowutils.StructFieldIDFromStruct(resSpansDT, constants.Resource)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	attributeIds, err := NewAttributeIds(resDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	droppedAttributesCount, _ := arrowutils.FieldIDFromStruct(resDT, constants.DroppedAttributesCount)
@@ -54,20 +53,20 @@ func NewResourceIds(resSpansDT *arrow.StructType) (*ResourceIds, error) {
 func UpdateResourceWith(r pcommon.Resource, resList *arrowutils.ListOfStructs, row int, resIds *ResourceIds) error {
 	_, resArr, err := resList.StructByID(resIds.Id, row)
 	if err != nil {
-		return err
+		return werror.WrapWithContext(err, map[string]interface{}{"row": row})
 	}
 
 	// Read dropped attributes count
 	droppedAttributesCount, err := arrowutils.U32FromStruct(resArr, row, resIds.DroppedAttributesCount)
 	if err != nil {
-		return err
+		return werror.WrapWithContext(err, map[string]interface{}{"row": row})
 	}
 	r.SetDroppedAttributesCount(droppedAttributesCount)
 
 	// Read attributes
 	err = AppendAttributesInto(r.Attributes(), resArr, row, resIds.Attributes)
 	if err != nil {
-		return fmt.Errorf("UpdateResourceWith->%w", err)
+		return werror.WrapWithContext(err, map[string]interface{}{"row": row})
 	}
 
 	return err

--- a/pkg/otel/common/otlp/scope.go
+++ b/pkg/otel/common/otlp/scope.go
@@ -34,7 +34,7 @@ type ScopeIds struct {
 func NewScopeIds(resSpansDT *arrow.StructType) (*ScopeIds, error) {
 	scopeID, scopeDT, err := arrowutils.StructFieldIDFromStruct(resSpansDT, constants.Scope)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	nameID, _ := arrowutils.FieldIDFromStruct(scopeDT, constants.Name)
@@ -42,7 +42,7 @@ func NewScopeIds(resSpansDT *arrow.StructType) (*ScopeIds, error) {
 	droppedAttributesCountID, _ := arrowutils.FieldIDFromStruct(scopeDT, constants.DroppedAttributesCount)
 	attributeIds, err := NewAttributeIds(scopeDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 	return &ScopeIds{
 		Id:                     scopeID,

--- a/pkg/otel/common/otlp/scope.go
+++ b/pkg/otel/common/otlp/scope.go
@@ -15,13 +15,12 @@
 package otlp
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type ScopeIds struct {
@@ -58,24 +57,24 @@ func NewScopeIds(resSpansDT *arrow.StructType) (*ScopeIds, error) {
 func UpdateScopeWith(s pcommon.InstrumentationScope, listOfStructs *arrowutils.ListOfStructs, row int, ids *ScopeIds) error {
 	_, scopeArray, err := listOfStructs.StructByID(ids.Id, row)
 	if err != nil {
-		return err
+		return werror.WrapWithContext(err, map[string]interface{}{"row": row})
 	}
 	name, err := arrowutils.StringFromStruct(scopeArray, row, ids.Name)
 	if err != nil {
-		return err
+		return werror.WrapWithContext(err, map[string]interface{}{"row": row})
 	}
 	version, err := arrowutils.StringFromStruct(scopeArray, row, ids.Version)
 	if err != nil {
-		return err
+		return werror.WrapWithContext(err, map[string]interface{}{"row": row})
 	}
 	droppedAttributesCount, err := arrowutils.U32FromStruct(scopeArray, row, ids.DroppedAttributesCount)
 	if err != nil {
-		return err
+		return werror.WrapWithContext(err, map[string]interface{}{"row": row})
 	}
 
 	err = AppendAttributesInto(s.Attributes(), scopeArray, row, ids.Attributes)
 	if err != nil {
-		return fmt.Errorf("UpdateScopeWith->%w", err)
+		return werror.WrapWithContext(err, map[string]interface{}{"row": row})
 	}
 	s.SetName(name)
 	s.SetVersion(version)

--- a/pkg/otel/common/schema/builder/record.go
+++ b/pkg/otel/common/schema/builder/record.go
@@ -30,6 +30,7 @@ import (
 	events "github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/events"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/transform"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/update"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 // RecordBuilderExt is a wrapper/decorator around array.RecordBuilder that
@@ -112,7 +113,7 @@ func (rb *RecordBuilderExt) NewRecord() (arrow.Record, error) {
 	// If field optionality has changed, update the schema
 	if !rb.IsSchemaUpToDate() {
 		rb.UpdateSchema()
-		return nil, schema.ErrSchemaNotUpToDate
+		return nil, werror.Wrap(schema.ErrSchemaNotUpToDate)
 	}
 
 	record := rb.recordBuilder.NewRecord()
@@ -128,7 +129,7 @@ func (rb *RecordBuilderExt) NewRecord() (arrow.Record, error) {
 	if !rb.IsSchemaUpToDate() {
 		record.Release()
 		rb.UpdateSchema()
-		return nil, schema.ErrSchemaNotUpToDate
+		return nil, werror.Wrap(schema.ErrSchemaNotUpToDate)
 	} else {
 		return record, nil
 	}
@@ -231,7 +232,7 @@ func copyDictValuesTo(srcRecBuilder *array.RecordBuilder, destRecBuilder *array.
 		if len(destFieldIndices) == 1 {
 			destBuilder := destRecBuilder.Field(destFieldIndices[0])
 			if err := copyFieldDictValuesTo(srcBuilder, destBuilder); err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 		}
 	}
@@ -296,10 +297,10 @@ func copyFieldDictValuesTo(srcBuilder array.Builder, destBuilder array.Builder) 
 		}
 	case *array.MapBuilder:
 		if err = copyFieldDictValuesTo(sBuilder.KeyBuilder(), destBuilder.(*array.MapBuilder).KeyBuilder()); err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		if err = copyFieldDictValuesTo(sBuilder.ItemBuilder(), destBuilder.(*array.MapBuilder).ItemBuilder()); err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 	case array.DictionaryBuilder:
 		srcDictArr := sBuilder.NewDictionaryArray()

--- a/pkg/otel/logs/arrow/log_record.go
+++ b/pkg/otel/logs/arrow/log_record.go
@@ -18,8 +18,6 @@
 package arrow
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -28,6 +26,7 @@ import (
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/builder"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 // Arrow Data Types describing log record and body.
@@ -88,7 +87,7 @@ func LogRecordBuilderFrom(sb *builder.StructBuilder) *LogRecordBuilder {
 // memory allocated by the array.
 func (b *LogRecordBuilder) Build() (*array.Struct, error) {
 	if b.released {
-		return nil, fmt.Errorf("log builder already released")
+		return nil, werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	defer b.Release()
@@ -98,7 +97,7 @@ func (b *LogRecordBuilder) Build() (*array.Struct, error) {
 // Append appends a new log record to the builder.
 func (b *LogRecordBuilder) Append(log plog.LogRecord) error {
 	if b.released {
-		return fmt.Errorf("log record builder already released")
+		return werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	return b.builder.Append(log, func() error {

--- a/pkg/otel/logs/arrow/log_record.go
+++ b/pkg/otel/logs/arrow/log_record.go
@@ -110,10 +110,10 @@ func (b *LogRecordBuilder) Append(log plog.LogRecord) error {
 		b.snb.AppendNonZero(int32(log.SeverityNumber()))
 		b.stb.AppendNonEmpty(log.SeverityText())
 		if err := b.bb.Append(log.Body()); err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		if err := b.ab.Append(log.Attributes()); err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		b.dacb.AppendNonZero(log.DroppedAttributesCount())
 		b.fb.Append(uint32(log.Flags()))

--- a/pkg/otel/logs/arrow/logs.go
+++ b/pkg/otel/logs/arrow/logs.go
@@ -18,8 +18,6 @@
 package arrow
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"go.opentelemetry.io/collector/pdata/plog"
 
@@ -71,7 +69,7 @@ func (b *LogsBuilder) init() error {
 // memory allocated by the record.
 func (b *LogsBuilder) Build() (record arrow.Record, err error) {
 	if b.released {
-		return nil, fmt.Errorf("resource logs builder already released")
+		return nil, werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	record, err = b.builder.NewRecord()
@@ -96,7 +94,7 @@ func (b *LogsBuilder) Append(logs plog.Logs) error {
 	return b.rlb.Append(rc, func() error {
 		for i := 0; i < rc; i++ {
 			if err := b.rlp.Append(rl.At(i)); err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 		}
 		return nil

--- a/pkg/otel/logs/arrow/logs.go
+++ b/pkg/otel/logs/arrow/logs.go
@@ -23,9 +23,11 @@ import (
 	"github.com/apache/arrow/go/v11/arrow"
 	"go.opentelemetry.io/collector/pdata/plog"
 
+	acommon "github.com/f5/otel-arrow-adapter/pkg/otel/common/arrow"
 	schema "github.com/f5/otel-arrow-adapter/pkg/otel/common/schema"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/builder"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 // Schema is the Arrow schema for the OTLP Arrow Logs record.
@@ -51,7 +53,7 @@ func NewLogsBuilder(recordBuilder *builder.RecordBuilderExt) (*LogsBuilder, erro
 		builder:  recordBuilder,
 	}
 	if err := b.init(); err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 	return b, nil
 }
@@ -76,7 +78,7 @@ func (b *LogsBuilder) Build() (record arrow.Record, err error) {
 	if err != nil {
 		initErr := b.init()
 		if initErr != nil {
-			err = initErr
+			err = werror.Wrap(initErr)
 		}
 	}
 
@@ -86,7 +88,7 @@ func (b *LogsBuilder) Build() (record arrow.Record, err error) {
 // Append appends a new set of resource logs to the builder.
 func (b *LogsBuilder) Append(logs plog.Logs) error {
 	if b.released {
-		return fmt.Errorf("traces builder already released")
+		return werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	rl := logs.ResourceLogs()

--- a/pkg/otel/logs/arrow/resource_logs.go
+++ b/pkg/otel/logs/arrow/resource_logs.go
@@ -83,7 +83,7 @@ func (b *ResourceLogsBuilder) Append(rs plog.ResourceLogs) error {
 
 	return b.builder.Append(rs, func() error {
 		if err := b.rb.Append(rs.Resource()); err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		b.schb.AppendNonEmpty(rs.SchemaUrl())
 		slogs := rs.ScopeLogs()
@@ -91,7 +91,7 @@ func (b *ResourceLogsBuilder) Append(rs plog.ResourceLogs) error {
 		return b.slsb.Append(sc, func() error {
 			for i := 0; i < sc; i++ {
 				if err := b.slb.Append(slogs.At(i)); err != nil {
-					return err
+					return werror.Wrap(err)
 				}
 			}
 			return nil

--- a/pkg/otel/logs/arrow/resource_logs.go
+++ b/pkg/otel/logs/arrow/resource_logs.go
@@ -18,8 +18,6 @@
 package arrow
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -28,6 +26,7 @@ import (
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/builder"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 var (
@@ -69,7 +68,7 @@ func ResourceLogsBuilderFrom(builder *builder.StructBuilder) *ResourceLogsBuilde
 // memory allocated by the array.
 func (b *ResourceLogsBuilder) Build() (*array.Struct, error) {
 	if b.released {
-		return nil, fmt.Errorf("resource logs builder already released")
+		return nil, werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	defer b.Release()
@@ -79,7 +78,7 @@ func (b *ResourceLogsBuilder) Build() (*array.Struct, error) {
 // Append appends a new resource logs to the builder.
 func (b *ResourceLogsBuilder) Append(rs plog.ResourceLogs) error {
 	if b.released {
-		return fmt.Errorf("resource logs builder already released")
+		return werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	return b.builder.Append(rs, func() error {

--- a/pkg/otel/logs/otlp/errors.go
+++ b/pkg/otel/logs/otlp/errors.go
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package otlp
+
+import "errors"
+
+var (
+	ErrBodyNotSparseUnion = errors.New("body is not a sparse union")
+)

--- a/pkg/otel/logs/otlp/logs.go
+++ b/pkg/otel/logs/otlp/logs.go
@@ -17,6 +17,8 @@ package otlp
 import (
 	"github.com/apache/arrow/go/v11/arrow"
 	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type LogsIds struct {
@@ -29,19 +31,17 @@ func LogsFrom(record arrow.Record) (plog.Logs, error) {
 
 	ids, err := SchemaToIds(record.Schema())
 	if err != nil {
-		return logs, err
+		return logs, werror.Wrap(err)
 	}
 
-	// TODO there is probably two nested lists that could be replaced by a single list (traces, resource spans). This could simplify a future query layer.
-
 	err = AppendResourceLogsInto(logs, record, ids)
-	return logs, err
+	return logs, werror.Wrap(err)
 }
 
 func SchemaToIds(schema *arrow.Schema) (*LogsIds, error) {
 	resLogsIds, err := NewResourceLogsIds(schema)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 	return &LogsIds{
 		ResourceLogs: resLogsIds,

--- a/pkg/otel/logs/otlp/resource_logs.go
+++ b/pkg/otel/logs/otlp/resource_logs.go
@@ -72,7 +72,7 @@ func AppendResourceLogsInto(logs plog.Logs, record arrow.Record, ids *LogsIds) e
 			resLogs := resLogsSlice.AppendEmpty()
 
 			if err = otlp.UpdateResourceWith(resLogs.Resource(), arrowResLogs, resLogsIdx, ids.ResourceLogs.Resource); err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 
 			schemaUrl, err := arrowResLogs.StringFieldByID(ids.ResourceLogs.SchemaUrl, resLogsIdx)

--- a/pkg/otel/logs/otlp/resource_logs.go
+++ b/pkg/otel/logs/otlp/resource_logs.go
@@ -21,6 +21,7 @@ import (
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
 	otlp "github.com/f5/otel-arrow-adapter/pkg/otel/common/otlp"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type ResourceLogsIds struct {
@@ -33,19 +34,19 @@ type ResourceLogsIds struct {
 func NewResourceLogsIds(schema *arrow.Schema) (*ResourceLogsIds, error) {
 	id, dt, err := arrowutils.ListOfStructsFieldIDFromSchema(schema, constants.ResourceLogs)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	schemaID, _ := arrowutils.FieldIDFromStruct(dt, constants.SchemaUrl)
 
 	scopeLogsIDs, err := NewScopeLogsIds(dt)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	resourceIDs, err := otlp.NewResourceIds(dt)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	return &ResourceLogsIds{
@@ -63,7 +64,7 @@ func AppendResourceLogsInto(logs plog.Logs, record arrow.Record, ids *LogsIds) e
 	for traceIdx := 0; traceIdx < resLogsCount; traceIdx++ {
 		arrowResLogs, err := arrowutils.ListOfStructsFromRecord(record, ids.ResourceLogs.Id, traceIdx)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		resLogsSlice.EnsureCapacity(resLogsSlice.Len() + arrowResLogs.End() - arrowResLogs.Start())
 
@@ -76,13 +77,13 @@ func AppendResourceLogsInto(logs plog.Logs, record arrow.Record, ids *LogsIds) e
 
 			schemaUrl, err := arrowResLogs.StringFieldByID(ids.ResourceLogs.SchemaUrl, resLogsIdx)
 			if err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 			resLogs.SetSchemaUrl(schemaUrl)
 
 			err = AppendScopeLogsInto(resLogs, arrowResLogs, resLogsIdx, ids.ResourceLogs.ScopeLogs)
 			if err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 		}
 	}

--- a/pkg/otel/logs/otlp/scope_logs.go
+++ b/pkg/otel/logs/otlp/scope_logs.go
@@ -15,14 +15,13 @@
 package otlp
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"go.opentelemetry.io/collector/pdata/plog"
 
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
 	otlp "github.com/f5/otel-arrow-adapter/pkg/otel/common/otlp"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type ScopeLogsIds struct {
@@ -39,19 +38,19 @@ func NewScopeLogsIds(dt *arrow.StructType) (*ScopeLogsIds, error) {
 
 	id, scopeSpansDT, err := arrowutils.ListOfStructsFieldIDFromStruct(dt, constants.ScopeLogs)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	schemaId, _ := arrowutils.FieldIDFromStruct(scopeSpansDT, constants.SchemaUrl)
 
 	scopeIds, err := otlp.NewScopeIds(scopeSpansDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	spansIds, err := NewLogRecordIds(scopeSpansDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	return &ScopeLogsIds{
@@ -65,7 +64,7 @@ func NewScopeLogsIds(dt *arrow.StructType) (*ScopeLogsIds, error) {
 func AppendScopeLogsInto(resLogs plog.ResourceLogs, arrowResLogs *arrowutils.ListOfStructs, resLogsIdx int, ids *ScopeLogsIds) error {
 	arrowScopeLogs, err := arrowResLogs.ListOfStructsById(resLogsIdx, ids.Id)
 	if err != nil {
-		return fmt.Errorf("AppendScopeLogsInto(field='scope')->%w", err)
+		return werror.Wrap(err)
 	}
 	scopeLogsSlice := resLogs.ScopeLogs()
 	scopeLogsSlice.EnsureCapacity(arrowScopeLogs.End() - arrowResLogs.Start())
@@ -79,20 +78,20 @@ func AppendScopeLogsInto(resLogs plog.ResourceLogs, arrowResLogs *arrowutils.Lis
 
 		schemaUrl, err := arrowScopeLogs.StringFieldByID(ids.SchemaUrl, scopeLogsIdx)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		scopeLogs.SetSchemaUrl(schemaUrl)
 
 		arrowLogs, err := arrowScopeLogs.ListOfStructsById(scopeLogsIdx, ids.LogRecordIds.Id)
 		if err != nil {
-			return fmt.Errorf("AppendScopeLogsInto(field='logs')->%w", err)
+			return werror.Wrap(err)
 		}
 		logsSlice := scopeLogs.LogRecords()
 		logsSlice.EnsureCapacity(arrowLogs.End() - arrowLogs.Start())
 		for logIdx := arrowLogs.Start(); logIdx < arrowLogs.End(); logIdx++ {
 			err = AppendLogRecordInto(logsSlice, arrowLogs, logIdx, ids.LogRecordIds)
 			if err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 		}
 	}

--- a/pkg/otel/logs/otlp/scope_logs.go
+++ b/pkg/otel/logs/otlp/scope_logs.go
@@ -73,7 +73,7 @@ func AppendScopeLogsInto(resLogs plog.ResourceLogs, arrowResLogs *arrowutils.Lis
 		scopeLogs := scopeLogsSlice.AppendEmpty()
 
 		if err = otlp.UpdateScopeWith(scopeLogs.Scope(), arrowScopeLogs, scopeLogsIdx, ids.ScopeIds); err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 
 		schemaUrl, err := arrowScopeLogs.StringFieldByID(ids.SchemaUrl, scopeLogsIdx)

--- a/pkg/otel/metrics/arrow/errors.go
+++ b/pkg/otel/metrics/arrow/errors.go
@@ -15,17 +15,10 @@
  *
  */
 
-package common
+package arrow
 
-import (
-	"errors"
-)
+import "errors"
 
 var (
-	ErrInvalidKeyMap         = errors.New("invalid key map")
-	ErrUnsupportedCborType   = errors.New("unsupported cbor type")
-	ErrInvalidTypeConversion = errors.New("invalid type conversion")
-
-	ErrInvalidSpanIDLength  = errors.New("invalid span id length")
-	ErrInvalidTraceIDLength = errors.New("invalid trace id length")
+	ErrUnknownMetricType = errors.New("unknown metric type")
 )

--- a/pkg/otel/metrics/arrow/exemplar.go
+++ b/pkg/otel/metrics/arrow/exemplar.go
@@ -15,8 +15,6 @@
 package arrow
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -25,6 +23,7 @@ import (
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/builder"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 var (
@@ -71,7 +70,7 @@ func ExemplarBuilderFrom(ex *builder.StructBuilder) *ExemplarBuilder {
 // memory allocated by the array.
 func (b *ExemplarBuilder) Build() (*array.Struct, error) {
 	if b.released {
-		return nil, fmt.Errorf("exemplar builder already released")
+		return nil, werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	defer b.Release()
@@ -81,16 +80,16 @@ func (b *ExemplarBuilder) Build() (*array.Struct, error) {
 // Append appends an exemplar to the builder.
 func (b *ExemplarBuilder) Append(ex pmetric.Exemplar) error {
 	if b.released {
-		return fmt.Errorf("exemplar builder already released")
+		return werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	return b.builder.Append(ex, func() error {
 		if err := b.ab.Append(ex.FilteredAttributes()); err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		b.tunb.Append(arrow.Timestamp(ex.Timestamp()))
 		if err := b.mvb.AppendExemplarValue(ex); err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 
 		sid := ex.SpanID()

--- a/pkg/otel/metrics/arrow/quantile_value.go
+++ b/pkg/otel/metrics/arrow/quantile_value.go
@@ -15,15 +15,15 @@
 package arrow
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
+	carrow "github.com/f5/otel-arrow-adapter/pkg/otel/common/arrow"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/builder"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 // QuantileValueDT is the Arrow Data Type describing a quantile value.
@@ -60,7 +60,7 @@ func QuantileValueBuilderFrom(ndpb *builder.StructBuilder) *QuantileValueBuilder
 // Once the array is no longer needed, Release() should be called to free the memory.
 func (b *QuantileValueBuilder) Build() (*array.Struct, error) {
 	if b.released {
-		return nil, fmt.Errorf("QuantileValueBuilder: Build() called after Release()")
+		return nil, werror.Wrap(carrow.ErrBuilderAlreadyReleased)
 	}
 
 	defer b.Release()
@@ -80,7 +80,7 @@ func (b *QuantileValueBuilder) Release() {
 // Append appends a new quantile value to the builder.
 func (b *QuantileValueBuilder) Append(sdp pmetric.SummaryDataPointValueAtQuantile) error {
 	if b.released {
-		return fmt.Errorf("QuantileValueBuilder: Reserve() called after Release()")
+		return werror.Wrap(carrow.ErrBuilderAlreadyReleased)
 	}
 
 	return b.builder.Append(sdp, func() error {

--- a/pkg/otel/metrics/arrow/univariate_ehdpb.go
+++ b/pkg/otel/metrics/arrow/univariate_ehdpb.go
@@ -15,15 +15,15 @@
 package arrow
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
+	acommon "github.com/f5/otel-arrow-adapter/pkg/otel/common/arrow"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/builder"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 // EHistogramDataPointBucketsDT is the Arrow Data Type describing an exponential histogram data point buckets.
@@ -63,7 +63,7 @@ func EHistogramDataPointBucketsBuilderFrom(b *builder.StructBuilder) *EHistogram
 // Once the array is no longer needed, Release() should be called to free the memory.
 func (b *EHistogramDataPointBucketsBuilder) Build() (*array.Struct, error) {
 	if b.released {
-		return nil, fmt.Errorf("EHistogramDataPointBucketsBuilder: Build() called after Release()")
+		return nil, werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	defer b.Release()
@@ -83,7 +83,7 @@ func (b *EHistogramDataPointBucketsBuilder) Release() {
 // Append appends a new histogram data point to the builder.
 func (b *EHistogramDataPointBucketsBuilder) Append(hdpb pmetric.ExponentialHistogramDataPointBuckets) error {
 	if b.released {
-		return fmt.Errorf("EHistogramDataPointBucketsBuilder: Reserve() called after Release()")
+		return werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	return b.builder.Append(hdpb, func() error {

--- a/pkg/otel/metrics/arrow/univariate_histogram.go
+++ b/pkg/otel/metrics/arrow/univariate_histogram.go
@@ -15,15 +15,15 @@
 package arrow
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
+	acommon "github.com/f5/otel-arrow-adapter/pkg/otel/common/arrow"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/builder"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 var (
@@ -64,7 +64,7 @@ func UnivariateHistogramBuilderFrom(b *builder.StructBuilder) *UnivariateHistogr
 // Once the array is no longer needed, Release() should be called to free the memory.
 func (b *UnivariateHistogramBuilder) Build() (*array.Struct, error) {
 	if b.released {
-		return nil, fmt.Errorf("UnivariateHistogramBuilder: Build() called after Release()")
+		return nil, werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	defer b.Release()
@@ -84,7 +84,7 @@ func (b *UnivariateHistogramBuilder) Release() {
 // Append appends a new histogram to the builder.
 func (b *UnivariateHistogramBuilder) Append(histogram pmetric.Histogram, smdata *ScopeMetricsSharedData, mdata *MetricSharedData) error {
 	if b.released {
-		return fmt.Errorf("UnivariateHistogramBuilder: Reserve() called after Release()")
+		return werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	return b.builder.Append(histogram, func() error {
@@ -93,12 +93,12 @@ func (b *UnivariateHistogramBuilder) Append(histogram pmetric.Histogram, smdata 
 		if err := b.hdplb.Append(dpc, func() error {
 			for i := 0; i < dpc; i++ {
 				if err := b.hdpb.Append(dps.At(i), smdata, mdata); err != nil {
-					return err
+					return werror.Wrap(err)
 				}
 			}
 			return nil
 		}); err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		if histogram.AggregationTemporality() == pmetric.AggregationTemporalityUnspecified {
 			b.atb.AppendNull()

--- a/pkg/otel/metrics/arrow/univariate_sum.go
+++ b/pkg/otel/metrics/arrow/univariate_sum.go
@@ -15,15 +15,15 @@
 package arrow
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
+	acommon "github.com/f5/otel-arrow-adapter/pkg/otel/common/arrow"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/builder"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 // UnivariateSumDT is the Arrow Data Type describing a univariate sum.
@@ -67,7 +67,7 @@ func UnivariateSumBuilderFrom(ndpb *builder.StructBuilder) *UnivariateSumBuilder
 // Once the array is no longer needed, Release() should be called to free the memory.
 func (b *UnivariateSumBuilder) Build() (*array.Struct, error) {
 	if b.released {
-		return nil, fmt.Errorf("UnivariateMetricBuilder: Build() called after Release()")
+		return nil, werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	defer b.Release()
@@ -87,7 +87,7 @@ func (b *UnivariateSumBuilder) Release() {
 // Append appends a new univariate sum to the builder.
 func (b *UnivariateSumBuilder) Append(sum pmetric.Sum, smdata *ScopeMetricsSharedData, mdata *MetricSharedData) error {
 	if b.released {
-		return fmt.Errorf("UnivariateMetricBuilder: Reserve() called after Release()")
+		return werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	return b.builder.Append(sum, func() error {
@@ -96,12 +96,12 @@ func (b *UnivariateSumBuilder) Append(sum pmetric.Sum, smdata *ScopeMetricsShare
 		if err := b.dplb.Append(dpc, func() error {
 			for i := 0; i < dpc; i++ {
 				if err := b.dpb.Append(dps.At(i), smdata, mdata); err != nil {
-					return err
+					return werror.Wrap(err)
 				}
 			}
 			return nil
 		}); err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		if sum.AggregationTemporality() == pmetric.AggregationTemporalityUnspecified {
 			b.atb.AppendNull()

--- a/pkg/otel/metrics/arrow/value.go
+++ b/pkg/otel/metrics/arrow/value.go
@@ -15,15 +15,15 @@
 package arrow
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
+	acommon "github.com/f5/otel-arrow-adapter/pkg/otel/common/arrow"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/builder"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 // Constants used to identify the type of value in the union.
@@ -69,7 +69,7 @@ func MetricValueBuilderFrom(mv *builder.SparseUnionBuilder) *MetricValueBuilder 
 // memory allocated by the array.
 func (b *MetricValueBuilder) Build() (*array.SparseUnion, error) {
 	if b.released {
-		return nil, fmt.Errorf("metric value builder already released")
+		return nil, werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	defer b.Release()
@@ -79,7 +79,7 @@ func (b *MetricValueBuilder) Build() (*array.SparseUnion, error) {
 // AppendNumberDataPointValue appends a new metric value to the builder.
 func (b *MetricValueBuilder) AppendNumberDataPointValue(mdp pmetric.NumberDataPoint) error {
 	if b.released {
-		return fmt.Errorf("metric value builder already released")
+		return werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	var err error
@@ -91,13 +91,13 @@ func (b *MetricValueBuilder) AppendNumberDataPointValue(mdp pmetric.NumberDataPo
 	case pmetric.NumberDataPointValueTypeEmpty:
 		// ignore empty data point.
 	}
-	return err
+	return werror.Wrap(err)
 }
 
 // AppendExemplarValue appends a new exemplar value to the builder.
 func (b *MetricValueBuilder) AppendExemplarValue(ex pmetric.Exemplar) error {
 	if b.released {
-		return fmt.Errorf("metric value builder already released")
+		return werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	var err error
@@ -109,7 +109,7 @@ func (b *MetricValueBuilder) AppendExemplarValue(ex pmetric.Exemplar) error {
 	case pmetric.ExemplarValueTypeEmpty:
 		// ignore empty exemplar.
 	}
-	return err
+	return werror.Wrap(err)
 }
 
 // Release releases the memory allocated by the builder.

--- a/pkg/otel/metrics/otlp/errors.go
+++ b/pkg/otel/metrics/otlp/errors.go
@@ -15,17 +15,18 @@
  *
  */
 
-package common
+package otlp
 
 import (
 	"errors"
 )
 
 var (
-	ErrInvalidKeyMap         = errors.New("invalid key map")
-	ErrUnsupportedCborType   = errors.New("unsupported cbor type")
-	ErrInvalidTypeConversion = errors.New("invalid type conversion")
-
-	ErrInvalidSpanIDLength  = errors.New("invalid span id length")
-	ErrInvalidTraceIDLength = errors.New("invalid trace id length")
+	ErrNotArraySparseUnion = errors.New("not an arrow array.SparseUnion")
+	ErrNotArrayInt32       = errors.New("not an arrow array.Int32")
+	ErrNotArrayUint64      = errors.New("not an arrow array.Uint64")
+	ErrNotArrayFloat64     = errors.New("not an arrow array.Float64")
+	ErrNotArrayList        = errors.New("not an arrow array.List")
+	ErrNotArrayBoolean     = errors.New("not an arrow array.Boolean")
+	ErrUnknownTypeCode     = errors.New("unknown type code")
 )

--- a/pkg/otel/metrics/otlp/metrics.go
+++ b/pkg/otel/metrics/otlp/metrics.go
@@ -17,6 +17,8 @@ package otlp
 import (
 	"github.com/apache/arrow/go/v11/arrow"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type MetricsIds struct {
@@ -36,9 +38,7 @@ func MetricsFrom(record arrow.Record) (pmetric.Metrics, error) {
 	resSpansCount := int(record.NumRows())
 	resMetricsSlice.EnsureCapacity(resSpansCount)
 
-	// TODO there is probably two nested lists that could be replaced by a single list (metrics, resource spans). This could simplify a future query layer.
-
-	err = AppendResourceMetricsInto(metrics, record, metricsIds)
+	err = werror.Wrap(AppendResourceMetricsInto(metrics, record, metricsIds))
 	return metrics, err
 }
 

--- a/pkg/otel/metrics/otlp/metrics.go
+++ b/pkg/otel/metrics/otlp/metrics.go
@@ -31,7 +31,7 @@ func MetricsFrom(record arrow.Record) (pmetric.Metrics, error) {
 
 	metricsIds, err := SchemaToIds(record.Schema())
 	if err != nil {
-		return metrics, err
+		return metrics, werror.Wrap(err)
 	}
 
 	resMetricsSlice := metrics.ResourceMetrics()
@@ -45,7 +45,7 @@ func MetricsFrom(record arrow.Record) (pmetric.Metrics, error) {
 func SchemaToIds(schema *arrow.Schema) (*MetricsIds, error) {
 	resMetricsIds, err := NewResourceMetricsIds(schema)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 	return &MetricsIds{
 		ResourceMetrics: resMetricsIds,

--- a/pkg/otel/metrics/otlp/quantile_value.go
+++ b/pkg/otel/metrics/otlp/quantile_value.go
@@ -15,13 +15,12 @@
 package otlp
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type QuantileValueIds struct {
@@ -33,7 +32,7 @@ type QuantileValueIds struct {
 func NewQuantileValueIds(parentDT *arrow.StructType) (*QuantileValueIds, error) {
 	id, quantileValueDT, err := arrowutils.ListOfStructsFieldIDFromStruct(parentDT, constants.SummaryQuantileValues)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	quantile, _ := arrowutils.FieldIDFromStruct(quantileValueDT, constants.SummaryQuantile)
@@ -49,7 +48,7 @@ func NewQuantileValueIds(parentDT *arrow.StructType) (*QuantileValueIds, error) 
 func AppendQuantileValuesInto(quantileSlice pmetric.SummaryDataPointValueAtQuantileSlice, ndp *arrowutils.ListOfStructs, ndpIdx int, ids *QuantileValueIds) error {
 	quantileValues, err := ndp.ListOfStructsById(ndpIdx, ids.Id)
 	if err != nil {
-		return fmt.Errorf("AppendQuantileValuesInto(field='quantile_values')->%w", err)
+		return werror.Wrap(err)
 	}
 	if quantileValues == nil {
 		return nil
@@ -64,13 +63,13 @@ func AppendQuantileValuesInto(quantileSlice pmetric.SummaryDataPointValueAtQuant
 
 		quantile, err := quantileValues.F64FieldByID(ids.Quantile, quantileIdx)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		quantileValue.SetQuantile(quantile)
 
 		value, err := quantileValues.F64FieldByID(ids.Value, quantileIdx)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		quantileValue.SetValue(value)
 	}

--- a/pkg/otel/metrics/otlp/resource_metrics.go
+++ b/pkg/otel/metrics/otlp/resource_metrics.go
@@ -23,6 +23,7 @@ import (
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
 	otlp "github.com/f5/otel-arrow-adapter/pkg/otel/common/otlp"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type ResourceMetricsIds struct {
@@ -94,7 +95,7 @@ func AppendResourceMetricsInto(metrics pmetric.Metrics, record arrow.Record, met
 			}
 			err = UpdateScopeMetricsFrom(resMetrics.ScopeMetrics(), arrowScopeMetrics, metricsIds.ResourceMetrics.ScopeMetrics)
 			if err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 		}
 	}

--- a/pkg/otel/metrics/otlp/resource_metrics.go
+++ b/pkg/otel/metrics/otlp/resource_metrics.go
@@ -15,8 +15,6 @@
 package otlp
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
@@ -37,23 +35,23 @@ type ResourceMetricsIds struct {
 func NewResourceMetricsIds(schema *arrow.Schema) (*ResourceMetricsIds, error) {
 	id, rsDT, err := arrowutils.ListOfStructsFieldIDFromSchema(schema, constants.ResourceMetrics)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	schemaId, _ := arrowutils.FieldIDFromStruct(rsDT, constants.SchemaUrl)
 
 	scopeMetricsId, scopeMetricsDT, err := arrowutils.ListOfStructsFieldIDFromStruct(rsDT, constants.ScopeMetrics)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 	scopeMetricsIds, err := NewScopeMetricsIds(scopeMetricsDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	resourceIds, err := otlp.NewResourceIds(rsDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	return &ResourceMetricsIds{
@@ -72,7 +70,7 @@ func AppendResourceMetricsInto(metrics pmetric.Metrics, record arrow.Record, met
 	for metricsIdx := 0; metricsIdx < resMetricsCount; metricsIdx++ {
 		arrowResEnts, err := arrowutils.ListOfStructsFromRecord(record, metricsIds.ResourceMetrics.Id, metricsIdx)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		resMetricsSlice.EnsureCapacity(resMetricsSlice.Len() + arrowResEnts.End() - arrowResEnts.Start())
 
@@ -80,18 +78,18 @@ func AppendResourceMetricsInto(metrics pmetric.Metrics, record arrow.Record, met
 			resMetrics := resMetricsSlice.AppendEmpty()
 
 			if err = otlp.UpdateResourceWith(resMetrics.Resource(), arrowResEnts, resMetricsIdx, metricsIds.ResourceMetrics.Resource); err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 
 			schemaUrl, err := arrowResEnts.StringFieldByID(metricsIds.ResourceMetrics.SchemaUrl, resMetricsIdx)
 			if err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 			resMetrics.SetSchemaUrl(schemaUrl)
 
 			arrowScopeMetrics, err := arrowResEnts.ListOfStructsById(resMetricsIdx, metricsIds.ResourceMetrics.ScopeMetricsId)
 			if err != nil {
-				return fmt.Errorf("AppendResourceMetricsInto(field='scope_metrics')->%w", err)
+				return werror.Wrap(err)
 			}
 			err = UpdateScopeMetricsFrom(resMetrics.ScopeMetrics(), arrowScopeMetrics, metricsIds.ResourceMetrics.ScopeMetrics)
 			if err != nil {

--- a/pkg/otel/metrics/otlp/scope_metrics.go
+++ b/pkg/otel/metrics/otlp/scope_metrics.go
@@ -24,6 +24,7 @@ import (
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
 	otlp "github.com/f5/otel-arrow-adapter/pkg/otel/common/otlp"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type ScopeMetricsIds struct {
@@ -102,7 +103,7 @@ func UpdateScopeMetricsFrom(scopeMetricsSlice pmetric.ScopeMetricsSlice, arrowSc
 		for entityIdx := arrowMetrics.Start(); entityIdx < arrowMetrics.End(); entityIdx++ {
 			err = AppendMetricSetInto(metricsSlice, arrowMetrics, entityIdx, ids.MetricSetIds, sdata)
 			if err != nil {
-				return fmt.Errorf("UpdateScopeMetricsFrom->%w", err)
+				return werror.Wrap(err)
 			}
 		}
 	}

--- a/pkg/otel/metrics/otlp/univariate_ehdp.go
+++ b/pkg/otel/metrics/otlp/univariate_ehdp.go
@@ -15,8 +15,6 @@
 package otlp
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -24,6 +22,7 @@ import (
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
 	otlp "github.com/f5/otel-arrow-adapter/pkg/otel/common/otlp"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 // UnivariateEHistogramDataPointIds is a struct containing the field ids for the
@@ -49,12 +48,12 @@ type UnivariateEHistogramDataPointIds struct {
 func NewUnivariateEHistogramDataPointIds(parentDT *arrow.StructType) (*UnivariateEHistogramDataPointIds, error) {
 	id, ehdpDT, err := arrowutils.ListOfStructsFieldIDFromStruct(parentDT, constants.DataPoints)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	attributes, err := otlp.NewAttributeIds(ehdpDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	startTimeUnixNanoID, _ := arrowutils.FieldIDFromStruct(ehdpDT, constants.StartTimeUnixNano)
@@ -66,25 +65,25 @@ func NewUnivariateEHistogramDataPointIds(parentDT *arrow.StructType) (*Univariat
 
 	positiveID, positiveDT, err := arrowutils.StructFieldIDFromStruct(ehdpDT, constants.ExpHistogramPositive)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 	positive, err := NewEHistogramDataPointBucketsIds(positiveID, positiveDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	negativeID, negativeDT, err := arrowutils.StructFieldIDFromStruct(ehdpDT, constants.ExpHistogramNegative)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 	negative, err := NewEHistogramDataPointBucketsIds(negativeID, negativeDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	exemplars, err := NewExemplarIds(ehdpDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	flagsID, _ := arrowutils.FieldIDFromStruct(ehdpDT, constants.Flags)
@@ -125,7 +124,7 @@ func AppendUnivariateEHistogramDataPointInto(ehdpSlice pmetric.ExponentialHistog
 
 		attrs := ehdpVal.Attributes()
 		if err := otlp.AppendAttributesInto(attrs, ehdp.Array(), ehdpIdx, ids.Attributes); err != nil {
-			return fmt.Errorf("AppendUnivariateEHistogramDataPointInto->%w", err)
+			return werror.Wrap(err)
 		}
 		smdata.Attributes.Range(func(k string, v pcommon.Value) bool {
 			v.CopyTo(attrs.PutEmpty(k))
@@ -144,7 +143,7 @@ func AppendUnivariateEHistogramDataPointInto(ehdpSlice pmetric.ExponentialHistog
 			} else {
 				startTimeUnixNano, err := ehdp.TimestampFieldByID(ids.StartTimeUnixNano, ehdpIdx)
 				if err != nil {
-					return err
+					return werror.Wrap(err)
 				}
 				ehdpVal.SetStartTimestamp(pcommon.Timestamp(startTimeUnixNano))
 			}
@@ -158,7 +157,7 @@ func AppendUnivariateEHistogramDataPointInto(ehdpSlice pmetric.ExponentialHistog
 			} else {
 				timeUnixNano, err := ehdp.TimestampFieldByID(ids.TimeUnixNano, ehdpIdx)
 				if err != nil {
-					return err
+					return werror.Wrap(err)
 				}
 				ehdpVal.SetTimestamp(pcommon.Timestamp(timeUnixNano))
 			}
@@ -166,59 +165,59 @@ func AppendUnivariateEHistogramDataPointInto(ehdpSlice pmetric.ExponentialHistog
 
 		err := AppendCountSumInto(ehdp, ids, ehdpIdx, ehdpVal)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 
 		scale, err := ehdp.I32FieldByID(ids.Scale, ehdpIdx)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		ehdpVal.SetScale(scale)
 
 		zeroCount, err := ehdp.U64FieldByID(ids.ZeroCount, ehdpIdx)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		ehdpVal.SetZeroCount(zeroCount)
 
 		_, positive, err := ehdp.StructByID(ids.Positive.Id, ehdpIdx)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		if positive != nil {
 			if err := AppendUnivariateEHistogramDataPointBucketsInto(ehdpVal.Positive(), positive, ids.Positive, ehdpIdx); err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 		}
 
 		_, negative, err := ehdp.StructByID(ids.Negative.Id, ehdpIdx)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		if negative != nil {
 			if err := AppendUnivariateEHistogramDataPointBucketsInto(ehdpVal.Negative(), negative, ids.Negative, ehdpIdx); err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 		}
 
 		exemplars, err := ehdp.ListOfStructsById(ehdpIdx, ids.Exemplars.Id)
 		if exemplars != nil && err == nil {
 			if err := AppendExemplarsInto(ehdpVal.Exemplars(), exemplars, ehdpIdx, ids.Exemplars); err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 		} else if err != nil {
-			return fmt.Errorf("AppendUnivariateEHistogramDataPointInto(field='exemplars')->%w", err)
+			return werror.Wrap(err)
 		}
 
 		flags, err := ehdp.U32FieldByID(ids.Flags, ehdpIdx)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		ehdpVal.SetFlags(pmetric.DataPointFlags(flags))
 
 		err = AppendMinMaxInto(ehdp, ids, ehdpIdx, ehdpVal)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 	}
 
@@ -228,7 +227,7 @@ func AppendUnivariateEHistogramDataPointInto(ehdpSlice pmetric.ExponentialHistog
 func AppendMinMaxInto(ehdp *arrowutils.ListOfStructs, ids *UnivariateEHistogramDataPointIds, ehdpIdx int, ehdpVal pmetric.ExponentialHistogramDataPoint) error {
 	min, err := ehdp.F64OrNilFieldByID(ids.Min, ehdpIdx)
 	if err != nil {
-		return fmt.Errorf("AppendMinMaxInto(field='min')->%w", err)
+		return werror.Wrap(err)
 	}
 	if min != nil {
 		ehdpVal.SetMin(*min)
@@ -236,7 +235,7 @@ func AppendMinMaxInto(ehdp *arrowutils.ListOfStructs, ids *UnivariateEHistogramD
 
 	max, err := ehdp.F64OrNilFieldByID(ids.Max, ehdpIdx)
 	if err != nil {
-		return fmt.Errorf("AppendMinMaxInto(field='max')->%w", err)
+		return werror.Wrap(err)
 	}
 	if max != nil {
 		ehdpVal.SetMax(*max)
@@ -247,16 +246,16 @@ func AppendMinMaxInto(ehdp *arrowutils.ListOfStructs, ids *UnivariateEHistogramD
 func AppendCountSumInto(ehdp *arrowutils.ListOfStructs, ids *UnivariateEHistogramDataPointIds, ehdpIdx int, ehdpVal pmetric.ExponentialHistogramDataPoint) error {
 	count, err := ehdp.U64FieldByID(ids.Count, ehdpIdx)
 	if err != nil {
-		return err
+		return werror.Wrap(err)
 	}
 	ehdpVal.SetCount(count)
 
 	sum, err := ehdp.F64OrNilFieldByID(ids.Sum, ehdpIdx)
 	if err != nil {
-		return fmt.Errorf("AppendCountSumInto(field='sum')->%w", err)
+		return werror.Wrap(err)
 	}
 	if sum != nil {
 		ehdpVal.SetSum(*sum)
 	}
-	return err
+	return werror.Wrap(err)
 }

--- a/pkg/otel/metrics/otlp/univariate_ehdpb.go
+++ b/pkg/otel/metrics/otlp/univariate_ehdpb.go
@@ -15,14 +15,13 @@
 package otlp
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type EHistogramDataPointBucketsIds struct {
@@ -52,7 +51,7 @@ func AppendUnivariateEHistogramDataPointBucketsInto(dpBuckets pmetric.Exponentia
 		if i32OffsetArr, ok := offsetArr.(*array.Int32); ok {
 			dpBuckets.SetOffset(i32OffsetArr.Value(row))
 		} else {
-			return fmt.Errorf("field %q is not an int32", constants.ExpHistogramOffset)
+			return werror.Wrap(ErrNotArrayInt32)
 		}
 	}
 
@@ -71,7 +70,7 @@ func AppendUnivariateEHistogramDataPointBucketsInto(dpBuckets pmetric.Exponentia
 				}
 			}
 		} else {
-			return fmt.Errorf("field %q is not an int64", constants.ExpHistogramBucketCounts)
+			return werror.Wrap(ErrNotArrayList)
 		}
 	}
 

--- a/pkg/otel/metrics/otlp/univariate_ehistogram.go
+++ b/pkg/otel/metrics/otlp/univariate_ehistogram.go
@@ -32,7 +32,7 @@ type UnivariateEHistogramIds struct {
 func NewUnivariateEHistogramIds(parentDT *arrow.StructType) (*UnivariateEHistogramIds, error) {
 	dataPoints, err := NewUnivariateEHistogramDataPointIds(parentDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	aggrTempId, _ := arrowutils.FieldIDFromStruct(parentDT, constants.AggregationTemporality)
@@ -60,5 +60,5 @@ func UpdateUnivariateEHistogramFrom(ehistogram pmetric.ExponentialHistogram, arr
 	if err != nil {
 		err = werror.WrapWithContext(err, map[string]interface{}{"row": row})
 	}
-	return err
+	return werror.Wrap(err)
 }

--- a/pkg/otel/metrics/otlp/univariate_ehistogram.go
+++ b/pkg/otel/metrics/otlp/univariate_ehistogram.go
@@ -15,14 +15,13 @@
 package otlp
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type UnivariateEHistogramIds struct {
@@ -48,18 +47,18 @@ func UpdateUnivariateEHistogramFrom(ehistogram pmetric.ExponentialHistogram, arr
 	if ids.AggregationTemporality >= 0 {
 		value, err := arrowutils.I32FromArray(arr.Field(ids.AggregationTemporality), row)
 		if err != nil {
-			return fmt.Errorf("UpdateUnivariateEHistogramFrom->%w", err)
+			return werror.WrapWithContext(err, map[string]interface{}{"row": row})
 		}
 		ehistogram.SetAggregationTemporality(pmetric.AggregationTemporality(value))
 	}
 
 	los, err := arrowutils.ListOfStructsFromStruct(arr, ids.DataPoints.Id, row)
 	if err != nil {
-		return fmt.Errorf("UpdateUnivariateEHistogramFrom->%w", err)
+		return werror.WrapWithContext(err, map[string]interface{}{"row": row})
 	}
 	err = AppendUnivariateEHistogramDataPointInto(ehistogram.DataPoints(), los, ids.DataPoints, smdata, mdata)
 	if err != nil {
-		err = fmt.Errorf("UpdateUnivariateEHistogramFrom->%w", err)
+		err = werror.WrapWithContext(err, map[string]interface{}{"row": row})
 	}
 	return err
 }

--- a/pkg/otel/metrics/otlp/univariate_gauge.go
+++ b/pkg/otel/metrics/otlp/univariate_gauge.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type UnivariateGaugeIds struct {
@@ -29,7 +30,7 @@ type UnivariateGaugeIds struct {
 func NewUnivariateGaugeIds(parentDT *arrow.StructType) (*UnivariateGaugeIds, error) {
 	dataPoints, err := NewUnivariateNdpIds(parentDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	return &UnivariateGaugeIds{
@@ -40,7 +41,7 @@ func NewUnivariateGaugeIds(parentDT *arrow.StructType) (*UnivariateGaugeIds, err
 func UpdateUnivariateGaugeFrom(gauge pmetric.Gauge, arr *array.Struct, row int, ids *UnivariateGaugeIds, smdata *SharedData, mdata *SharedData) error {
 	los, err := arrowutils.ListOfStructsFromStruct(arr, ids.DataPoints.Id, row)
 	if err != nil {
-		return err
+		return werror.Wrap(err)
 	}
 	return AppendUnivariateNdpInto(gauge.DataPoints(), los, ids.DataPoints, smdata, mdata)
 }

--- a/pkg/otel/metrics/otlp/univariate_histogram.go
+++ b/pkg/otel/metrics/otlp/univariate_histogram.go
@@ -15,14 +15,13 @@
 package otlp
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type UnivariateHistogramIds struct {
@@ -48,18 +47,18 @@ func UpdateUnivariateHistogramFrom(histogram pmetric.Histogram, arr *array.Struc
 	if ids.AggregationTemporality >= 0 {
 		value, err := arrowutils.I32FromArray(arr.Field(ids.AggregationTemporality), row)
 		if err != nil {
-			return fmt.Errorf("UpdateUnivariateHistogramFrom->%w", err)
+			return werror.WrapWithContext(err, map[string]interface{}{"row": row})
 		}
 		histogram.SetAggregationTemporality(pmetric.AggregationTemporality(value))
 	}
 
 	los, err := arrowutils.ListOfStructsFromStruct(arr, ids.DataPoints.Id, row)
 	if err != nil {
-		return fmt.Errorf("UpdateUnivariateHistogramFrom->%w", err)
+		return werror.WrapWithContext(err, map[string]interface{}{"row": row})
 	}
 	err = AppendUnivariateHistogramDataPointInto(histogram.DataPoints(), los, ids.DataPoints, smdata, mdata)
 	if err != nil {
-		err = fmt.Errorf("UpdateUnivariateHistogramFrom->%w", err)
+		err = werror.WrapWithContext(err, map[string]interface{}{"row": row})
 	}
 	return err
 }

--- a/pkg/otel/metrics/otlp/univariate_histogram.go
+++ b/pkg/otel/metrics/otlp/univariate_histogram.go
@@ -32,7 +32,7 @@ type UnivariateHistogramIds struct {
 func NewUnivariateHistogramIds(parentDT *arrow.StructType) (*UnivariateHistogramIds, error) {
 	dataPoints, err := NewUnivariateHistogramDataPointIds(parentDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	aggrTempId, _ := arrowutils.FieldIDFromStruct(parentDT, constants.AggregationTemporality)
@@ -60,5 +60,5 @@ func UpdateUnivariateHistogramFrom(histogram pmetric.Histogram, arr *array.Struc
 	if err != nil {
 		err = werror.WrapWithContext(err, map[string]interface{}{"row": row})
 	}
-	return err
+	return werror.Wrap(err)
 }

--- a/pkg/otel/metrics/otlp/univariate_metric.go
+++ b/pkg/otel/metrics/otlp/univariate_metric.go
@@ -24,6 +24,7 @@ import (
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
 	ametric "github.com/f5/otel-arrow-adapter/pkg/otel/metrics/arrow"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type UnivariateMetricIds struct {
@@ -113,7 +114,7 @@ func UpdateUnivariateMetricFrom(metric pmetric.Metric, arr *array.SparseUnion, r
 		err = fmt.Errorf("UpdateUnivariateMetricFrom: unknown type code %d", tcode)
 	}
 	if err != nil {
-		err = fmt.Errorf("UpdateUnivariateMetricFrom->%w", err)
+		err = werror.WrapWithContext(err, map[string]interface{}{"row": row})
 	}
 	return
 }

--- a/pkg/otel/metrics/otlp/univariate_summary.go
+++ b/pkg/otel/metrics/otlp/univariate_summary.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type UnivariateSummaryIds struct {
@@ -29,7 +30,7 @@ type UnivariateSummaryIds struct {
 func NewUnivariateSummaryIds(parentDT *arrow.StructType) (*UnivariateSummaryIds, error) {
 	dataPoints, err := NewUnivariateSdpIds(parentDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	return &UnivariateSummaryIds{
@@ -40,7 +41,7 @@ func NewUnivariateSummaryIds(parentDT *arrow.StructType) (*UnivariateSummaryIds,
 func UpdateUnivariateSummaryFrom(summary pmetric.Summary, arr *array.Struct, row int, ids *UnivariateSummaryIds, smdata *SharedData, mdata *SharedData) error {
 	los, err := arrowutils.ListOfStructsFromStruct(arr, ids.DataPoints.Id, row)
 	if err != nil {
-		return err
+		return werror.Wrap(err)
 	}
 	return AppendUnivariateSdpInto(summary.DataPoints(), los, ids.DataPoints, smdata, mdata)
 }

--- a/pkg/otel/metrics/otlp/value.go
+++ b/pkg/otel/metrics/otlp/value.go
@@ -15,13 +15,12 @@
 package otlp
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
 	arrow "github.com/f5/otel-arrow-adapter/pkg/otel/metrics/arrow"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 func UpdateValueFromExemplar(v pmetric.Exemplar, vArr *array.SparseUnion, row int) error {
@@ -32,17 +31,17 @@ func UpdateValueFromExemplar(v pmetric.Exemplar, vArr *array.SparseUnion, row in
 	case arrow.I64Code:
 		val, err := arrowutils.I64FromArray(vArr.Field(fieldId), row)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		v.SetIntValue(val)
 	case arrow.F64Code:
 		val, err := arrowutils.F64FromArray(vArr.Field(fieldId), row)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		v.SetDoubleValue(val)
 	default:
-		return fmt.Errorf("UpdateValueFromExemplar: unknow type code `%d` in sparse union array", tcode)
+		return werror.WrapWithContext(ErrUnknownTypeCode, map[string]interface{}{"typeCode": tcode, "row": row})
 	}
 	return nil
 }
@@ -55,17 +54,17 @@ func UpdateValueFromNumberDataPoint(v pmetric.NumberDataPoint, vArr *array.Spars
 	case arrow.I64Code:
 		val, err := arrowutils.I64FromArray(vArr.Field(fieldId), row)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		v.SetIntValue(val)
 	case arrow.F64Code:
 		val, err := arrowutils.F64FromArray(vArr.Field(fieldId), row)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		v.SetDoubleValue(val)
 	default:
-		return fmt.Errorf("UpdateValueFromNumberDataPoint: unknow type code `%d` in sparse union array", tcode)
+		return werror.WrapWithContext(ErrUnknownTypeCode, map[string]interface{}{"typeCode": tcode, "row": row})
 	}
 	return nil
 }

--- a/pkg/otel/traces/arrow/event.go
+++ b/pkg/otel/traces/arrow/event.go
@@ -18,8 +18,6 @@
 package arrow
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -28,6 +26,7 @@ import (
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/builder"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 // EventDT is the Arrow Data Type describing a span event.
@@ -65,7 +64,7 @@ func EventBuilderFrom(eb *builder.StructBuilder) *EventBuilder {
 // Append appends a new event to the builder.
 func (b *EventBuilder) Append(event ptrace.SpanEvent) error {
 	if b.released {
-		return fmt.Errorf("event builder already released")
+		return werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	return b.builder.Append(event, func() error {
@@ -82,7 +81,7 @@ func (b *EventBuilder) Append(event ptrace.SpanEvent) error {
 // memory allocated by the array.
 func (b *EventBuilder) Build() (*array.Struct, error) {
 	if b.released {
-		return nil, fmt.Errorf("event builder already released")
+		return nil, werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	defer b.Release()

--- a/pkg/otel/traces/arrow/link.go
+++ b/pkg/otel/traces/arrow/link.go
@@ -18,8 +18,6 @@
 package arrow
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -28,6 +26,7 @@ import (
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/builder"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 // LinkDT is the Arrow Data Type describing a link event.
@@ -68,7 +67,7 @@ func LinkBuilderFrom(lb *builder.StructBuilder) *LinkBuilder {
 // Append appends a new link to the builder.
 func (b *LinkBuilder) Append(link ptrace.SpanLink) error {
 	if b.released {
-		return fmt.Errorf("link builder already released")
+		return werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	return b.builder.Append(link, func() error {
@@ -88,7 +87,7 @@ func (b *LinkBuilder) Append(link ptrace.SpanLink) error {
 // memory allocated by the array.
 func (b *LinkBuilder) Build() (*array.Struct, error) {
 	if b.released {
-		return nil, fmt.Errorf("link builder already released")
+		return nil, werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	defer b.Release()

--- a/pkg/otel/traces/arrow/status.go
+++ b/pkg/otel/traces/arrow/status.go
@@ -18,15 +18,15 @@
 package arrow
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"github.com/apache/arrow/go/v11/arrow/array"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
+	acommon "github.com/f5/otel-arrow-adapter/pkg/otel/common/arrow"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/schema/builder"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 // StatusDT is the Arrow Data Type describing a span status.
@@ -58,7 +58,7 @@ func StatusBuilderFrom(sb *builder.StructBuilder) *StatusBuilder {
 // Append appends a new span status to the builder.
 func (b *StatusBuilder) Append(status ptrace.Status) error {
 	if b.released {
-		return fmt.Errorf("status builder already released")
+		return werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	return b.builder.Append(status, func() error {
@@ -74,7 +74,7 @@ func (b *StatusBuilder) Append(status ptrace.Status) error {
 // memory allocated by the array.
 func (b *StatusBuilder) Build() (*array.Struct, error) {
 	if b.released {
-		return nil, fmt.Errorf("status builder already released")
+		return nil, werror.Wrap(acommon.ErrBuilderAlreadyReleased)
 	}
 
 	defer b.Release()

--- a/pkg/otel/traces/otlp/event.go
+++ b/pkg/otel/traces/otlp/event.go
@@ -15,8 +15,6 @@
 package otlp
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -24,6 +22,7 @@ import (
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
 	otlp "github.com/f5/otel-arrow-adapter/pkg/otel/common/otlp"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type EventIds struct {
@@ -37,7 +36,7 @@ type EventIds struct {
 func NewEventIds(spansDT *arrow.StructType) (*EventIds, error) {
 	id, eventDT, err := arrowutils.ListOfStructsFieldIDFromStruct(spansDT, constants.SpanEvents)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	timeUnixNanoID, _ := arrowutils.FieldIDFromStruct(eventDT, constants.TimeUnixNano)
@@ -45,7 +44,7 @@ func NewEventIds(spansDT *arrow.StructType) (*EventIds, error) {
 	droppedAttributesCountId, _ := arrowutils.FieldIDFromStruct(eventDT, constants.DroppedAttributesCount)
 	attributesID, err := otlp.NewAttributeIds(eventDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	return &EventIds{
@@ -61,7 +60,7 @@ func NewEventIds(spansDT *arrow.StructType) (*EventIds, error) {
 func AppendEventsInto(spans ptrace.SpanEventSlice, arrowSpans *arrowutils.ListOfStructs, spanIdx int, ids *EventIds) error {
 	events, err := arrowSpans.ListOfStructsById(spanIdx, ids.Id)
 	if err != nil {
-		return fmt.Errorf("AppendEventsInto(field='events')->%w", err)
+		return werror.Wrap(err)
 	}
 	if events == nil {
 		// No event found
@@ -77,25 +76,25 @@ func AppendEventsInto(spans ptrace.SpanEventSlice, arrowSpans *arrowutils.ListOf
 
 		timeUnixNano, err := events.TimestampFieldByID(ids.TimeUnixNano, eventIdx)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 
 		event.SetTimestamp(pcommon.Timestamp(timeUnixNano))
 
 		name, err := events.StringFieldByID(ids.Name, eventIdx)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 
 		event.SetName(name)
 
 		if err = otlp.AppendAttributesInto(event.Attributes(), events.Array(), eventIdx, ids.Attributes); err != nil {
-			return fmt.Errorf("AppendEventsInto->%w", err)
+			return werror.Wrap(err)
 		}
 
 		dac, err := events.U32FieldByID(ids.DroppedAttributesCount, eventIdx)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 
 		event.SetDroppedAttributesCount(dac)

--- a/pkg/otel/traces/otlp/resource_spans.go
+++ b/pkg/otel/traces/otlp/resource_spans.go
@@ -21,6 +21,7 @@ import (
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
 	otlp "github.com/f5/otel-arrow-adapter/pkg/otel/common/otlp"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type ResourceSpansIds struct {
@@ -33,19 +34,19 @@ type ResourceSpansIds struct {
 func NewResourceSpansIds(schema *arrow.Schema) (*ResourceSpansIds, error) {
 	id, rsDT, err := arrowutils.ListOfStructsFieldIDFromSchema(schema, constants.ResourceSpans)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	schemaId, _ := arrowutils.FieldIDFromStruct(rsDT, constants.SchemaUrl)
 
 	scopeSpansIds, err := NewScopeSpansIds(rsDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	resourceIds, err := otlp.NewResourceIds(rsDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	return &ResourceSpansIds{
@@ -63,7 +64,7 @@ func AppendResourceSpansInto(traces ptrace.Traces, record arrow.Record, traceIds
 	for traceIdx := 0; traceIdx < resSpansCount; traceIdx++ {
 		arrowResEnts, err := arrowutils.ListOfStructsFromRecord(record, traceIds.ResourceSpans.Id, traceIdx)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		resSpansSlice.EnsureCapacity(resSpansSlice.Len() + arrowResEnts.End() - arrowResEnts.Start())
 
@@ -71,18 +72,18 @@ func AppendResourceSpansInto(traces ptrace.Traces, record arrow.Record, traceIds
 			resSpans := resSpansSlice.AppendEmpty()
 
 			if err = otlp.UpdateResourceWith(resSpans.Resource(), arrowResEnts, resSpansIdx, traceIds.ResourceSpans.Resource); err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 
 			schemaUrl, err := arrowResEnts.StringFieldByID(traceIds.ResourceSpans.SchemaUrl, resSpansIdx)
 			if err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 			resSpans.SetSchemaUrl(schemaUrl)
 
 			err = AppendScopeSpansInto(resSpans, arrowResEnts, resSpansIdx, traceIds.ResourceSpans.ScopeSpans)
 			if err != nil {
-				return err
+				return werror.Wrap(err)
 			}
 		}
 	}

--- a/pkg/otel/traces/otlp/span.go
+++ b/pkg/otel/traces/otlp/span.go
@@ -15,15 +15,15 @@
 package otlp
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/v11/arrow"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	arrowutils "github.com/f5/otel-arrow-adapter/pkg/arrow"
+	"github.com/f5/otel-arrow-adapter/pkg/otel/common"
 	otlp "github.com/f5/otel-arrow-adapter/pkg/otel/common/otlp"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/constants"
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type SpansIds struct {
@@ -54,7 +54,7 @@ type StatusIds struct {
 func NewSpansIds(scopeSpansDT *arrow.StructType) (*SpansIds, error) {
 	id, spanDT, err := arrowutils.ListOfStructsFieldIDFromStruct(scopeSpansDT, constants.Spans)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	traceId, _ := arrowutils.FieldIDFromStruct(spanDT, constants.TraceId)
@@ -67,25 +67,25 @@ func NewSpansIds(scopeSpansDT *arrow.StructType) (*SpansIds, error) {
 	endTimeUnixNano, _ := arrowutils.FieldIDFromStruct(spanDT, constants.EndTimeUnixNano)
 	attributes, err := otlp.NewAttributeIds(spanDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 	droppedAttributesCount, _ := arrowutils.FieldIDFromStruct(spanDT, constants.DroppedAttributesCount)
 	events, err := NewEventIds(spanDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	droppedEventsCount, _ := arrowutils.FieldIDFromStruct(spanDT, constants.DroppedEventsCount)
 	links, err := NewLinkIds(spanDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	droppedLinksCount, _ := arrowutils.FieldIDFromStruct(spanDT, constants.DroppedLinksCount)
 
 	status, err := NewStatusIds(spanDT)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	return &SpansIds{
@@ -111,7 +111,7 @@ func NewSpansIds(scopeSpansDT *arrow.StructType) (*SpansIds, error) {
 func NewStatusIds(spansDT *arrow.StructType) (*StatusIds, error) {
 	statusId, statusDT, err := arrowutils.StructFieldIDFromStruct(spansDT, constants.Status)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 
 	code, _ := arrowutils.FieldIDFromStruct(statusDT, constants.StatusCode)
@@ -126,94 +126,94 @@ func NewStatusIds(spansDT *arrow.StructType) (*StatusIds, error) {
 
 func AppendSpanInto(spans ptrace.SpanSlice, los *arrowutils.ListOfStructs, row int, ids *SpansIds) error {
 	span := spans.AppendEmpty()
-	traceId, err := los.FixedSizeBinaryFieldByID(ids.TraceId, row)
+	traceID, err := los.FixedSizeBinaryFieldByID(ids.TraceId, row)
 	if err != nil {
-		return err
+		return werror.Wrap(err)
 	}
-	if len(traceId) != 16 {
-		return fmt.Errorf("trace_id field should be 16 bytes")
+	if len(traceID) != 16 {
+		return werror.WrapWithContext(common.ErrInvalidTraceIDLength, map[string]interface{}{"traceID": traceID})
 	}
-	spanId, err := los.FixedSizeBinaryFieldByID(ids.SpanId, row)
+	spanID, err := los.FixedSizeBinaryFieldByID(ids.SpanId, row)
 	if err != nil {
-		return err
+		return werror.Wrap(err)
 	}
-	if len(spanId) != 8 {
-		return fmt.Errorf("span_id field should be 8 bytes")
+	if len(spanID) != 8 {
+		return werror.WrapWithContext(common.ErrInvalidSpanIDLength, map[string]interface{}{"spanID": spanID})
 	}
 	traceState, err := los.StringFieldByID(ids.TraceState, row)
 	if err != nil {
-		return err
+		return werror.Wrap(err)
 	}
-	parentSpanId, err := los.FixedSizeBinaryFieldByID(ids.ParentSpanId, row)
+	parentSpanID, err := los.FixedSizeBinaryFieldByID(ids.ParentSpanId, row)
 	if err != nil {
-		return err
+		return werror.Wrap(err)
 	}
-	if parentSpanId != nil && len(parentSpanId) != 8 {
-		return fmt.Errorf("parent_span_id field should be 8 bytes")
+	if parentSpanID != nil && len(parentSpanID) != 8 {
+		return werror.WrapWithContext(common.ErrInvalidSpanIDLength, map[string]interface{}{"parentSpanID": parentSpanID})
 	}
 	name, err := los.StringFieldByID(ids.Name, row)
 	if err != nil {
-		return err
+		return werror.Wrap(err)
 	}
 	kind, err := los.I32FieldByID(ids.Kind, row)
 	if err != nil {
-		return err
+		return werror.Wrap(err)
 	}
 	startTimeUnixNano, err := los.TimestampFieldByID(ids.StartTimeUnixNano, row)
 	if err != nil {
-		return err
+		return werror.Wrap(err)
 	}
 	endTimeUnixNano, err := los.TimestampFieldByID(ids.EndTimeUnixNano, row)
 	if err != nil {
-		return err
+		return werror.Wrap(err)
 	}
 	droppedAttributesCount, err := los.U32FieldByID(ids.DropAttributesCount, row)
 	if err != nil {
-		return err
+		return werror.Wrap(err)
 	}
 	droppedEventsCount, err := los.U32FieldByID(ids.DropEventsCount, row)
 	if err != nil {
-		return err
+		return werror.Wrap(err)
 	}
 	droppedLinksCount, err := los.U32FieldByID(ids.DropLinksCount, row)
 	if err != nil {
-		return err
+		return werror.Wrap(err)
 	}
 	statusDt, statusArr, err := los.StructByID(ids.Status.Id, row)
 	if err != nil {
-		return err
+		return werror.Wrap(err)
 	}
 	if statusDt != nil {
 		// Status exists
 		message, err := arrowutils.StringFromStruct(statusArr, row, ids.Status.Message)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		span.Status().SetMessage(message)
 
 		code, err := arrowutils.I32FromStruct(statusArr, row, ids.Status.Code)
 		if err != nil {
-			return err
+			return werror.Wrap(err)
 		}
 		span.Status().SetCode(ptrace.StatusCode(code))
 	}
 	err = otlp.AppendAttributesInto(span.Attributes(), los.Array(), row, ids.Attributes)
 	if err != nil {
-		return fmt.Errorf("AppendSpanInto->%w", err)
+		return werror.Wrap(err)
 	}
 
 	if err := AppendEventsInto(span.Events(), los, row, ids.Events); err != nil {
-		return err
+		return werror.Wrap(err)
 	}
 	if err := AppendLinksInto(span.Links(), los, row, ids.Links); err != nil {
-		return err
+		return werror.Wrap(err)
 	}
 	var tid pcommon.TraceID
 	var sid pcommon.SpanID
 	var psid pcommon.SpanID
-	copy(tid[:], traceId)
-	copy(sid[:], spanId)
-	copy(psid[:], parentSpanId)
+	copy(tid[:], traceID)
+	copy(sid[:], spanID)
+	copy(psid[:], parentSpanID)
 
 	span.SetTraceID(tid)
 	span.SetSpanID(sid)

--- a/pkg/otel/traces/otlp/traces.go
+++ b/pkg/otel/traces/otlp/traces.go
@@ -17,6 +17,8 @@ package otlp
 import (
 	"github.com/apache/arrow/go/v11/arrow"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/f5/otel-arrow-adapter/pkg/werror"
 )
 
 type TraceIds struct {
@@ -36,8 +38,6 @@ func TracesFrom(record arrow.Record) (ptrace.Traces, error) {
 	resSpansCount := int(record.NumRows())
 	resSpansSlice.EnsureCapacity(resSpansCount)
 
-	// TODO there is probably two nested lists that could be replaced by a single list (traces, resource spans). This could simplify a future query layer.
-
 	err = AppendResourceSpansInto(traces, record, traceIds)
 	return traces, err
 }
@@ -45,7 +45,7 @@ func TracesFrom(record arrow.Record) (ptrace.Traces, error) {
 func SchemaToIds(schema *arrow.Schema) (*TraceIds, error) {
 	resSpansIds, err := NewResourceSpansIds(schema)
 	if err != nil {
-		return nil, err
+		return nil, werror.Wrap(err)
 	}
 	return &TraceIds{
 		ResourceSpans: resSpansIds,

--- a/pkg/werror/error.go
+++ b/pkg/werror/error.go
@@ -15,7 +15,7 @@
  *
  */
 
-package error
+package werror
 
 import (
 	"fmt"
@@ -107,4 +107,12 @@ func WrapWithContext(err error, context map[string]interface{}) error {
 		function: fn.Name(),
 		context:  context,
 	}
+}
+
+func WrapWithMsg(err error, msg string) error {
+	if err == nil {
+		return nil
+	}
+
+	return WrapWithContext(err, map[string]interface{}{"msg": msg})
 }

--- a/pkg/werror/error_test.go
+++ b/pkg/werror/error_test.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package werror
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWError(t *testing.T) {
+	t.Parallel()
+
+	err := Level1a()
+	require.Equal(t, "github.com/f5/otel-arrow-adapter/pkg/werror.Wrap:90->github.com/f5/otel-arrow-adapter/pkg/werror.Level2:48{id=1}->test error", err.Error())
+
+	err = Level1b()
+	require.Equal(t, "github.com/f5/otel-arrow-adapter/pkg/werror.Wrap:90->github.com/f5/otel-arrow-adapter/pkg/werror.Level2:48{id=2}->test error", err.Error())
+}
+
+var ErrTest = errors.New("test error")
+
+func Level1a() error {
+	return Wrap(Level2(1))
+}
+
+func Level1b() error {
+	return Wrap(Level2(2))
+}
+
+func Level2(id int) error {
+	return WrapWithContext(ErrTest, map[string]interface{}{"id": id})
+}


### PR DESCRIPTION
This PR improves the error handling within the OTEL Arrow Adapter:
- Errors are wrapper with the file, function, and line location.
- An optional context can be attached to the wrapped errors at any level of the stack.

werror.Wrap(err)
werror.WrapWithMsg(err, "a messag")
werror.WrapWithContext(err, map[string]interface{}{"ctx1": 1, "ctx2": "bla", ...})