### PR TITLE
Fix error in werror.Wrap and werror.WrapWithMsg

### DIFF
--- a/pkg/werror/error_test.go
+++ b/pkg/werror/error_test.go
@@ -28,10 +28,10 @@ func TestWError(t *testing.T) {
 	t.Parallel()
 
 	err := Level1a()
-	require.Equal(t, "github.com/f5/otel-arrow-adapter/pkg/werror.Wrap:90->github.com/f5/otel-arrow-adapter/pkg/werror.Level2:48{id=1}->test error", err.Error())
+	require.Equal(t, "github.com/f5/otel-arrow-adapter/pkg/werror.Level1a:40->github.com/f5/otel-arrow-adapter/pkg/werror.Level2:48{id=1}->test error", err.Error())
 
 	err = Level1b()
-	require.Equal(t, "github.com/f5/otel-arrow-adapter/pkg/werror.Wrap:90->github.com/f5/otel-arrow-adapter/pkg/werror.Level2:48{id=2}->test error", err.Error())
+	require.Equal(t, "github.com/f5/otel-arrow-adapter/pkg/werror.Level1b:44->github.com/f5/otel-arrow-adapter/pkg/werror.Level2:48{id=2}->test error", err.Error())
 }
 
 var ErrTest = errors.New("test error")


### PR DESCRIPTION
#127 

Function name is correct for 'WrapWithContext', but incorrect for 'Wrap', and 'WrapWithMsg'.