### PR TITLE
Fix memory reuse issue

### DIFF
--- a/pkg/otel/arrow_record/producer.go
+++ b/pkg/otel/arrow_record/producer.go
@@ -284,7 +284,9 @@ func (p *Producer) Produce(rms []*RecordMessage) (*colarspb.BatchArrowRecords, e
 			if err != nil {
 				return werror.Wrap(err)
 			}
-			buf := sp.output.Bytes()
+			outputBuf := sp.output.Bytes()
+			buf := make([]byte, len(outputBuf))
+			copy(buf, outputBuf)
 
 			// Reset the buffer
 			sp.output.Reset()


### PR DESCRIPTION
In situations where we receive multiple OTel objects, there is a buffer that gets reused across different objects within the same batch. To prevent memory reuse issues, it's essential to create a copy of this buffer.