### PR TITLE
Collect a bunch of stats in the TracesOptimizer.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2 // indirect
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962 // indirect
+	github.com/HdrHistogram/hdrhistogram-go v1.1.2 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/apache/thrift v0.16.0 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,11 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962 h1:KeNholpO2xKjgaaSyd+DyQRrsQjhbSeS7qe4nEw8aQw=
 github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962/go.mod h1:kC29dT1vFpj7py2OvG1khBdQpo3kInWP+6QipLbdngo=
+github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
+github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c h1:RGWPOewvKIROun94nF7v2cua9qP+thov/7M50KEoeSU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -119,6 +122,7 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -155,6 +159,7 @@ github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
@@ -285,6 +290,7 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/asmfmt v1.3.2 h1:4Ri7ox3EwapiOjCki+hw14RyKk201CN4rzyCJRFLpK4=
@@ -355,6 +361,7 @@ github.com/mostynb/go-grpc-compression v1.1.17 h1:N9t6taOJN3mNTTi0wDf4e3lp/G/ON1
 github.com/mostynb/go-grpc-compression v1.1.17/go.mod h1:FUSBr0QjKqQgoDG/e0yiqlR6aqyXC39+g/hFLDfSsEY=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
@@ -550,7 +557,10 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
+golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/exp v0.0.0-20190829153037-c13cbed26979/go.mod h1:86+5VVa7VpoJ4kLfm080zCjGlMRFzhUhsZKEZO7MGek=
@@ -562,6 +572,7 @@ golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EH
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 h1:tnebWN09GYg9OLPss1KXj8txwZc6X6uMr6VFdcGNbHw=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
+golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -724,8 +735,10 @@ golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312151545-0bb0c0a6e846/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
@@ -777,8 +790,12 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f h1:uF6paiQQebLeSXkrTqHqz0MXhXXS1KgF41eUdBNvxK0=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
+gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/gonum v0.12.0 h1:xKuo6hzt+gMav00meVPUlXwSdoEJP46BR+wdxQEFK2o=
 gonum.org/v1/gonum v0.12.0/go.mod h1:73TDxJfAAHeA8Mk9mf8NlIppyhQNo5GLTcYeqgo2lvY=
+gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
+gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
@@ -880,6 +897,7 @@ gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d/go.mod h1:cuepJuh7vyXfUy
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
@@ -904,6 +922,7 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
+rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/pkg/benchmark/profileable/arrow/logs.go
+++ b/pkg/benchmark/profileable/arrow/logs.go
@@ -32,7 +32,7 @@ const OtlpArrow = "OTLP_ARROW"
 
 var logsProducerOptions = []arrow_record.Option{
 	arrow_record.WithNoZstd(),
-	//arrow_record.WithLogsStats(),
+	arrow_record.WithLogsStats(),
 }
 
 type LogsProfileable struct {

--- a/pkg/benchmark/profileable/arrow/logs.go
+++ b/pkg/benchmark/profileable/arrow/logs.go
@@ -30,6 +30,11 @@ import (
 
 const OtlpArrow = "OTLP_ARROW"
 
+var logsProducerOptions = []arrow_record.Option{
+	arrow_record.WithNoZstd(),
+	//arrow_record.WithLogsStats(),
+}
+
 type LogsProfileable struct {
 	tags              []string
 	compression       benchmark.CompressionAlgorithm
@@ -48,7 +53,7 @@ func NewLogsProfileable(tags []string, dataset dataset.LogsDataset, config *benc
 		tags:              tags,
 		dataset:           dataset,
 		compression:       benchmark.Zstd(),
-		producer:          arrow_record.NewProducerWithOptions(arrow_record.WithNoZstd()),
+		producer:          arrow_record.NewProducerWithOptions(logsProducerOptions...),
 		consumer:          arrow_record.NewConsumer(),
 		batchArrowRecords: make([]*v1.BatchArrowRecords, 0, 10),
 		config:            config,
@@ -80,7 +85,7 @@ func (s *LogsProfileable) CompressionAlgorithm() benchmark.CompressionAlgorithm 
 }
 func (s *LogsProfileable) StartProfiling(_ io.Writer) {
 	if !s.unaryRpcMode {
-		s.producer = arrow_record.NewProducerWithOptions(arrow_record.WithNoZstd())
+		s.producer = arrow_record.NewProducerWithOptions(logsProducerOptions...)
 		s.consumer = arrow_record.NewConsumer()
 	}
 }
@@ -97,7 +102,7 @@ func (s *LogsProfileable) EndProfiling(_ io.Writer) {
 func (s *LogsProfileable) InitBatchSize(_ io.Writer, _ int) {}
 func (s *LogsProfileable) PrepareBatch(_ io.Writer, startAt, size int) {
 	if s.unaryRpcMode {
-		s.producer = arrow_record.NewProducerWithOptions(arrow_record.WithNoZstd())
+		s.producer = arrow_record.NewProducerWithOptions(logsProducerOptions...)
 		s.consumer = arrow_record.NewConsumer()
 	}
 	s.logs = s.dataset.Logs(startAt, size)
@@ -169,4 +174,9 @@ func (s *LogsProfileable) Clear() {
 		}
 	}
 }
-func (s *LogsProfileable) ShowStats() {}
+func (s *LogsProfileable) ShowStats() {
+	stats := s.producer.LogsStats()
+	if stats != nil {
+		stats.Show()
+	}
+}

--- a/pkg/benchmark/profileable/arrow/metrics.go
+++ b/pkg/benchmark/profileable/arrow/metrics.go
@@ -28,6 +28,11 @@ import (
 	"github.com/f5/otel-arrow-adapter/pkg/otel/arrow_record"
 )
 
+var metricsProducerOptions = []arrow_record.Option{
+	arrow_record.WithNoZstd(),
+	//arrow_record.WithMetricsStats(),
+}
+
 type MetricsProfileable struct {
 	tags              []string
 	compression       benchmark.CompressionAlgorithm
@@ -46,7 +51,7 @@ func NewMetricsProfileable(tags []string, dataset dataset.MetricsDataset, config
 		tags:              tags,
 		dataset:           dataset,
 		compression:       benchmark.Zstd(),
-		producer:          arrow_record.NewProducerWithOptions(arrow_record.WithNoZstd()),
+		producer:          arrow_record.NewProducerWithOptions(metricsProducerOptions...),
 		consumer:          arrow_record.NewConsumer(),
 		batchArrowRecords: make([]*colarspb.BatchArrowRecords, 0, 10),
 		config:            config,
@@ -78,7 +83,7 @@ func (s *MetricsProfileable) CompressionAlgorithm() benchmark.CompressionAlgorit
 }
 func (s *MetricsProfileable) StartProfiling(_ io.Writer) {
 	if !s.unaryRpcMode {
-		s.producer = arrow_record.NewProducerWithOptions(arrow_record.WithNoZstd())
+		s.producer = arrow_record.NewProducerWithOptions(metricsProducerOptions...)
 		s.consumer = arrow_record.NewConsumer()
 	}
 }
@@ -95,7 +100,7 @@ func (s *MetricsProfileable) EndProfiling(_ io.Writer) {
 func (s *MetricsProfileable) InitBatchSize(_ io.Writer, _ int) {}
 func (s *MetricsProfileable) PrepareBatch(_ io.Writer, startAt, size int) {
 	if s.unaryRpcMode {
-		s.producer = arrow_record.NewProducerWithOptions(arrow_record.WithNoZstd())
+		s.producer = arrow_record.NewProducerWithOptions(metricsProducerOptions...)
 		s.consumer = arrow_record.NewConsumer()
 	}
 
@@ -168,4 +173,9 @@ func (s *MetricsProfileable) Clear() {
 		}
 	}
 }
-func (s *MetricsProfileable) ShowStats() {}
+func (s *MetricsProfileable) ShowStats() {
+	stats := s.producer.MetricsStats()
+	if stats != nil {
+		stats.Show()
+	}
+}

--- a/pkg/benchmark/profileable/arrow/metrics.go
+++ b/pkg/benchmark/profileable/arrow/metrics.go
@@ -30,7 +30,7 @@ import (
 
 var metricsProducerOptions = []arrow_record.Option{
 	arrow_record.WithNoZstd(),
-	//arrow_record.WithMetricsStats(),
+	arrow_record.WithMetricsStats(),
 }
 
 type MetricsProfileable struct {

--- a/pkg/benchmark/profileable/arrow/traces.go
+++ b/pkg/benchmark/profileable/arrow/traces.go
@@ -28,6 +28,10 @@ import (
 	"github.com/f5/otel-arrow-adapter/pkg/otel/arrow_record"
 )
 
+var tracesProducerOptions = []arrow_record.Option{
+	arrow_record.WithNoZstd(),
+}
+
 type TracesProfileable struct {
 	tags              []string
 	compression       benchmark.CompressionAlgorithm
@@ -46,7 +50,7 @@ func NewTraceProfileable(tags []string, dataset dataset.TraceDataset, config *be
 		tags:              tags,
 		dataset:           dataset,
 		compression:       benchmark.Zstd(),
-		producer:          arrow_record.NewProducerWithOptions(arrow_record.WithNoZstd()),
+		producer:          arrow_record.NewProducerWithOptions(tracesProducerOptions...),
 		consumer:          arrow_record.NewConsumer(),
 		batchArrowRecords: make([]*v1.BatchArrowRecords, 0, 10),
 		config:            config,
@@ -78,7 +82,7 @@ func (s *TracesProfileable) CompressionAlgorithm() benchmark.CompressionAlgorith
 }
 func (s *TracesProfileable) StartProfiling(_ io.Writer) {
 	if !s.unaryRpcMode {
-		s.producer = arrow_record.NewProducerWithOptions(arrow_record.WithNoZstd())
+		s.producer = arrow_record.NewProducerWithOptions(tracesProducerOptions...)
 		s.consumer = arrow_record.NewConsumer()
 	}
 }
@@ -95,7 +99,7 @@ func (s *TracesProfileable) EndProfiling(_ io.Writer) {
 func (s *TracesProfileable) InitBatchSize(_ io.Writer, _ int) {}
 func (s *TracesProfileable) PrepareBatch(_ io.Writer, startAt, size int) {
 	if s.unaryRpcMode {
-		s.producer = arrow_record.NewProducerWithOptions(arrow_record.WithNoZstd())
+		s.producer = arrow_record.NewProducerWithOptions(tracesProducerOptions...)
 		s.consumer = arrow_record.NewConsumer()
 	}
 

--- a/pkg/benchmark/profileable/arrow/traces.go
+++ b/pkg/benchmark/profileable/arrow/traces.go
@@ -30,6 +30,7 @@ import (
 
 var tracesProducerOptions = []arrow_record.Option{
 	arrow_record.WithNoZstd(),
+	arrow_record.WithTracesStats(),
 }
 
 type TracesProfileable struct {

--- a/pkg/benchmark/profileable/arrow/traces.go
+++ b/pkg/benchmark/profileable/arrow/traces.go
@@ -171,4 +171,9 @@ func (s *TracesProfileable) Clear() {
 		}
 	}
 }
-func (s *TracesProfileable) ShowStats() {}
+func (s *TracesProfileable) ShowStats() {
+	stats := s.producer.TracesStats()
+	if stats != nil {
+		stats.Show()
+	}
+}

--- a/pkg/otel/arrow_record/producer.go
+++ b/pkg/otel/arrow_record/producer.go
@@ -82,6 +82,9 @@ type Config struct {
 	initIndexSize  uint64
 	limitIndexSize uint64
 	zstd           bool // Use IPC ZSTD compression
+	metricsStats   bool
+	logsStats      bool
+	tracesStats    bool
 }
 
 type Option func(*Config)
@@ -102,6 +105,9 @@ func NewProducerWithOptions(options ...Option) *Producer {
 		pool:           memory.NewGoAllocator(),
 		initIndexSize:  math.MaxUint16,
 		limitIndexSize: math.MaxUint16,
+		metricsStats:   false,
+		logsStats:      false,
+		tracesStats:    false,
 		zstd:           true,
 	}
 	for _, opt := range options {
@@ -130,7 +136,7 @@ func NewProducerWithOptions(options ...Option) *Producer {
 		panic(err)
 	}
 
-	tracesBuilder, err := tracesarrow.NewTracesBuilder(tracesRecordBuilder)
+	tracesBuilder, err := tracesarrow.NewTracesBuilder(tracesRecordBuilder, cfg.tracesStats)
 	if err != nil {
 		panic(err)
 	}
@@ -230,6 +236,10 @@ func (p *Producer) LogsRecordBuilderExt() *builder.RecordBuilderExt {
 // TracesRecordBuilderExt returns the record builder used to encode traces.
 func (p *Producer) TracesRecordBuilderExt() *builder.RecordBuilderExt {
 	return p.tracesRecordBuilder
+}
+
+func (p *Producer) TracesStats() *tracesarrow.TracesStats {
+	return p.tracesBuilder.Stats()
 }
 
 // Close closes all stream producers.
@@ -434,5 +444,23 @@ func WithZstd() Option {
 func WithNoZstd() Option {
 	return func(cfg *Config) {
 		cfg.zstd = false
+	}
+}
+
+func WithMetricsStats() Option {
+	return func(cfg *Config) {
+		cfg.metricsStats = true
+	}
+}
+
+func WithLogsStats() Option {
+	return func(cfg *Config) {
+		cfg.logsStats = true
+	}
+}
+
+func WithTracesStats() Option {
+	return func(cfg *Config) {
+		cfg.tracesStats = true
 	}
 }

--- a/pkg/otel/arrow_record/producer.go
+++ b/pkg/otel/arrow_record/producer.go
@@ -126,12 +126,12 @@ func NewProducerWithOptions(options ...Option) *Producer {
 		MaxCard: cfg.limitIndexSize,
 	})
 
-	metricsBuilder, err := metricsarrow.NewMetricsBuilder(metricsRecordBuilder)
+	metricsBuilder, err := metricsarrow.NewMetricsBuilder(metricsRecordBuilder, cfg.metricsStats)
 	if err != nil {
 		panic(err)
 	}
 
-	logsBuidler, err := logsarrow.NewLogsBuilder(logsRecordBuilder)
+	logsBuidler, err := logsarrow.NewLogsBuilder(logsRecordBuilder, cfg.logsStats)
 	if err != nil {
 		panic(err)
 	}
@@ -236,6 +236,14 @@ func (p *Producer) LogsRecordBuilderExt() *builder.RecordBuilderExt {
 // TracesRecordBuilderExt returns the record builder used to encode traces.
 func (p *Producer) TracesRecordBuilderExt() *builder.RecordBuilderExt {
 	return p.tracesRecordBuilder
+}
+
+func (p *Producer) MetricsStats() *metricsarrow.MetricsStats {
+	return p.metricsBuilder.Stats()
+}
+
+func (p *Producer) LogsStats() *logsarrow.LogsStats {
+	return p.logsBuilder.Stats()
 }
 
 func (p *Producer) TracesStats() *tracesarrow.TracesStats {

--- a/pkg/otel/logs/arrow/all_test.go
+++ b/pkg/otel/logs/arrow/all_test.go
@@ -215,7 +215,7 @@ func TestLogs(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		tb, err := NewLogsBuilder(rBuilder)
+		tb, err := NewLogsBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer tb.Release()
 

--- a/pkg/otel/logs/arrow/logs.go
+++ b/pkg/otel/logs/arrow/logs.go
@@ -46,11 +46,19 @@ type LogsBuilder struct {
 }
 
 // NewLogsBuilder creates a new LogsBuilder with a given allocator.
-func NewLogsBuilder(recordBuilder *builder.RecordBuilderExt) (*LogsBuilder, error) {
+func NewLogsBuilder(recordBuilder *builder.RecordBuilderExt, logsStats bool) (*LogsBuilder, error) {
+	var optimizer *LogsOptimizer
+
+	if logsStats {
+		optimizer = NewLogsOptimizer(acommon.WithStats())
+	} else {
+		optimizer = NewLogsOptimizer()
+	}
+
 	b := &LogsBuilder{
 		released:  false,
 		builder:   recordBuilder,
-		optimizer: NewLogsOptimizer(),
+		optimizer: optimizer,
 	}
 	if err := b.init(); err != nil {
 		return nil, werror.Wrap(err)
@@ -63,6 +71,10 @@ func (b *LogsBuilder) init() error {
 	b.rlb = rlb
 	b.rlp = ResourceLogsBuilderFrom(rlb.StructBuilder())
 	return nil
+}
+
+func (b *LogsBuilder) Stats() *LogsStats {
+	return b.optimizer.Stats()
 }
 
 // Build builds an Arrow Record from the builder.

--- a/pkg/otel/logs/arrow/optimizer.go
+++ b/pkg/otel/logs/arrow/optimizer.go
@@ -18,20 +18,21 @@
 package arrow
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
+	"github.com/HdrHistogram/hdrhistogram-go"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 
-	"github.com/f5/otel-arrow-adapter/pkg/benchmark/stats"
 	carrow "github.com/f5/otel-arrow-adapter/pkg/otel/common/arrow"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/otlp"
 )
 
 type LogsOptimizer struct {
 	sort  bool
-	stats *stats.LogsStats
+	stats *LogsStats
 }
 
 type LogsOptimized struct {
@@ -53,6 +54,23 @@ type ScopeLogGroup struct {
 	Logs []*plog.LogRecord
 }
 
+type LogsStats struct {
+	LogsCount              int
+	ResourceLogsHistogram  *hdrhistogram.Histogram
+	ResourceAttrsHistogram *hdrhistogram.Histogram
+	ScopeLogsHistogram     *hdrhistogram.Histogram
+	ScopeAttrsHistogram    *hdrhistogram.Histogram
+	LogsHistogram          *hdrhistogram.Histogram
+	LogsAttrsHistogram     *hdrhistogram.Histogram
+	IntBodyHistogram       *hdrhistogram.Histogram
+	DoubleBodyHistogram    *hdrhistogram.Histogram
+	StringBodyHistogram    *hdrhistogram.Histogram
+	BoolBodyHistogram      *hdrhistogram.Histogram
+	ListBodyHistogram      *hdrhistogram.Histogram
+	MapBodyHistogram       *hdrhistogram.Histogram
+	BytesBodyHistogram     *hdrhistogram.Histogram
+}
+
 func NewLogsOptimizer(cfg ...func(*carrow.Options)) *LogsOptimizer {
 	options := carrow.Options{
 		Sort:  false,
@@ -62,9 +80,24 @@ func NewLogsOptimizer(cfg ...func(*carrow.Options)) *LogsOptimizer {
 		c(&options)
 	}
 
-	var s *stats.LogsStats
+	var s *LogsStats
 	if options.Stats {
-		s = stats.NewLogsStats()
+		s = &LogsStats{
+			LogsCount:              0,
+			ResourceLogsHistogram:  hdrhistogram.New(1, 1000000, 1),
+			ResourceAttrsHistogram: hdrhistogram.New(1, 1000000, 1),
+			ScopeLogsHistogram:     hdrhistogram.New(1, 1000000, 1),
+			ScopeAttrsHistogram:    hdrhistogram.New(1, 1000000, 1),
+			LogsHistogram:          hdrhistogram.New(1, 1000000, 1),
+			LogsAttrsHistogram:     hdrhistogram.New(1, 1000000, 1),
+			IntBodyHistogram:       hdrhistogram.New(1, 1000000, 1),
+			DoubleBodyHistogram:    hdrhistogram.New(1, 1000000, 1),
+			StringBodyHistogram:    hdrhistogram.New(1, 1000000, 1),
+			BoolBodyHistogram:      hdrhistogram.New(1, 1000000, 1),
+			ListBodyHistogram:      hdrhistogram.New(1, 1000000, 1),
+			MapBodyHistogram:       hdrhistogram.New(1, 1000000, 1),
+			BytesBodyHistogram:     hdrhistogram.New(1, 1000000, 1),
+		}
 	}
 
 	return &LogsOptimizer{
@@ -91,7 +124,29 @@ func (t *LogsOptimizer) Optimize(logs plog.Logs) *LogsOptimized {
 		}
 	}
 
+	if t.stats != nil {
+		logsOptimized.RecordStats(t.stats)
+	}
+
 	return logsOptimized
+}
+
+func (t *LogsOptimizer) Stats() *LogsStats {
+	return t.stats
+}
+
+func (t *LogsOptimized) RecordStats(stats *LogsStats) {
+	stats.LogsCount++
+	if err := stats.ResourceLogsHistogram.RecordValue(int64(len(t.ResourceLogs))); err != nil {
+		panic(fmt.Sprintf("number of resource logs is out of range: %v", err))
+	}
+	for _, resLogsGroup := range t.ResourceLogs {
+		attrs := resLogsGroup.Resource.Attributes()
+		if err := stats.ResourceAttrsHistogram.RecordValue(int64(attrs.Len())); err != nil {
+			panic(fmt.Sprintf("number of resource attrs is out of range: %v", err))
+		}
+		resLogsGroup.RecordStats(stats)
+	}
 }
 
 func (t *LogsOptimized) AddResourceLogs(resLogs *plog.ResourceLogs) {
@@ -147,4 +202,185 @@ func (r *ResourceLogGroup) Sort() {
 			) == -1
 		})
 	}
+}
+
+func (t *ResourceLogGroup) RecordStats(stats *LogsStats) {
+	if err := stats.ScopeLogsHistogram.RecordValue(int64(len(t.ScopeLogs))); err != nil {
+		panic(fmt.Sprintf("number of scope logs is out of range: %v", err))
+	}
+	for _, scopeLogsGroup := range t.ScopeLogs {
+		attrs := scopeLogsGroup.Scope.Attributes()
+		if err := stats.ScopeAttrsHistogram.RecordValue(int64(attrs.Len())); err != nil {
+			panic(fmt.Sprintf("number of scope attributes is out of range: %v", err))
+		}
+		scopeLogsGroup.RecordStats(stats)
+	}
+}
+
+func (t *ScopeLogGroup) RecordStats(stats *LogsStats) {
+	if err := stats.LogsHistogram.RecordValue(int64(len(t.Logs))); err != nil {
+		panic(fmt.Sprintf("number of logs is out of range: %v", err))
+	}
+
+	intCount := 0
+	doubleCount := 0
+	stringCount := 0
+	boolCount := 0
+	listCount := 0
+	mapCount := 0
+	bytesCount := 0
+
+	for _, log := range t.Logs {
+		if err := stats.LogsAttrsHistogram.RecordValue(int64(log.Attributes().Len())); err != nil {
+			panic(fmt.Sprintf("number of log attributes is out of range: %v", err))
+		}
+		switch log.Body().Type() {
+		case pcommon.ValueTypeInt:
+			intCount++
+		case pcommon.ValueTypeDouble:
+			doubleCount++
+		case pcommon.ValueTypeStr:
+			stringCount++
+		case pcommon.ValueTypeBool:
+			boolCount++
+		case pcommon.ValueTypeSlice:
+			listCount++
+		case pcommon.ValueTypeMap:
+			mapCount++
+		case pcommon.ValueTypeBytes:
+			bytesCount++
+		default: /* ignore */
+		}
+	}
+
+	if err := stats.IntBodyHistogram.RecordValue(int64(intCount)); err != nil {
+		panic(fmt.Sprintf("number of int body is out of range: %v", err))
+	}
+	if err := stats.DoubleBodyHistogram.RecordValue(int64(doubleCount)); err != nil {
+		panic(fmt.Sprintf("number of double body is out of range: %v", err))
+	}
+	if err := stats.StringBodyHistogram.RecordValue(int64(stringCount)); err != nil {
+		panic(fmt.Sprintf("number of string body is out of range: %v", err))
+	}
+	if err := stats.BoolBodyHistogram.RecordValue(int64(boolCount)); err != nil {
+		panic(fmt.Sprintf("number of bool body is out of range: %v", err))
+	}
+	if err := stats.ListBodyHistogram.RecordValue(int64(listCount)); err != nil {
+		panic(fmt.Sprintf("number of list body is out of range: %v", err))
+	}
+	if err := stats.MapBodyHistogram.RecordValue(int64(mapCount)); err != nil {
+		panic(fmt.Sprintf("number of map body is out of range: %v", err))
+	}
+	if err := stats.BytesBodyHistogram.RecordValue(int64(bytesCount)); err != nil {
+		panic(fmt.Sprintf("number of bytes body is out of range: %v", err))
+	}
+}
+
+func (t *LogsStats) Show() {
+	println("\nLogs stats (after optimization):")
+	fmt.Printf("\tNumber of log batches: %d\n", t.LogsCount)
+	fmt.Printf("\tResource logs/Batch  : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.ResourceLogsHistogram.Mean(),
+		t.ResourceLogsHistogram.Min(),
+		t.ResourceLogsHistogram.Max(),
+		t.ResourceLogsHistogram.StdDev(),
+		t.ResourceLogsHistogram.ValueAtQuantile(50),
+		t.ResourceLogsHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tAttributes/Resource  : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.ResourceAttrsHistogram.Mean(),
+		t.ResourceAttrsHistogram.Min(),
+		t.ResourceAttrsHistogram.Max(),
+		t.ResourceAttrsHistogram.StdDev(),
+		t.ResourceAttrsHistogram.ValueAtQuantile(50),
+		t.ResourceAttrsHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tScope logs/Resource  : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.ScopeLogsHistogram.Mean(),
+		t.ScopeLogsHistogram.Min(),
+		t.ScopeLogsHistogram.Max(),
+		t.ScopeLogsHistogram.StdDev(),
+		t.ScopeLogsHistogram.ValueAtQuantile(50),
+		t.ScopeLogsHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tAttributes/Scope     : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.ScopeAttrsHistogram.Mean(),
+		t.ScopeAttrsHistogram.Min(),
+		t.ScopeAttrsHistogram.Max(),
+		t.ScopeAttrsHistogram.StdDev(),
+		t.ScopeAttrsHistogram.ValueAtQuantile(50),
+		t.ScopeAttrsHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tNumber of logs/Scope : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.LogsHistogram.Mean(),
+		t.LogsHistogram.Min(),
+		t.LogsHistogram.Max(),
+		t.LogsHistogram.StdDev(),
+		t.LogsHistogram.ValueAtQuantile(50),
+		t.LogsHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tAttributes/Log       : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.LogsAttrsHistogram.Mean(),
+		t.LogsAttrsHistogram.Min(),
+		t.LogsAttrsHistogram.Max(),
+		t.LogsAttrsHistogram.StdDev(),
+		t.LogsAttrsHistogram.ValueAtQuantile(50),
+		t.LogsAttrsHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tInt body/Log         : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.IntBodyHistogram.Mean(),
+		t.IntBodyHistogram.Min(),
+		t.IntBodyHistogram.Max(),
+		t.IntBodyHistogram.StdDev(),
+		t.IntBodyHistogram.ValueAtQuantile(50),
+		t.IntBodyHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tDouble body/Log      : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.DoubleBodyHistogram.Mean(),
+		t.DoubleBodyHistogram.Min(),
+		t.DoubleBodyHistogram.Max(),
+		t.DoubleBodyHistogram.StdDev(),
+		t.DoubleBodyHistogram.ValueAtQuantile(50),
+		t.DoubleBodyHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tString body/Log      : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.StringBodyHistogram.Mean(),
+		t.StringBodyHistogram.Min(),
+		t.StringBodyHistogram.Max(),
+		t.StringBodyHistogram.StdDev(),
+		t.StringBodyHistogram.ValueAtQuantile(50),
+		t.StringBodyHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tBool body/Log        : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.BoolBodyHistogram.Mean(),
+		t.BoolBodyHistogram.Min(),
+		t.BoolBodyHistogram.Max(),
+		t.BoolBodyHistogram.StdDev(),
+		t.BoolBodyHistogram.ValueAtQuantile(50),
+		t.BoolBodyHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tMap body/Log         : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.MapBodyHistogram.Mean(),
+		t.MapBodyHistogram.Min(),
+		t.MapBodyHistogram.Max(),
+		t.MapBodyHistogram.StdDev(),
+		t.MapBodyHistogram.ValueAtQuantile(50),
+		t.MapBodyHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tList body/Log        : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.ListBodyHistogram.Mean(),
+		t.ListBodyHistogram.Min(),
+		t.ListBodyHistogram.Max(),
+		t.ListBodyHistogram.StdDev(),
+		t.ListBodyHistogram.ValueAtQuantile(50),
+		t.ListBodyHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tBytes body/Log       : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.BytesBodyHistogram.Mean(),
+		t.BytesBodyHistogram.Min(),
+		t.BytesBodyHistogram.Max(),
+		t.BytesBodyHistogram.StdDev(),
+		t.BytesBodyHistogram.ValueAtQuantile(50),
+		t.BytesBodyHistogram.ValueAtQuantile(99),
+	)
 }

--- a/pkg/otel/logs/validation_test.go
+++ b/pkg/otel/logs/validation_test.go
@@ -61,7 +61,7 @@ func TestConversionFromSyntheticData(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		lb, err := logsarrow.NewLogsBuilder(rBuilder)
+		lb, err := logsarrow.NewLogsBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer lb.Release()
 		err = lb.Append(expectedRequest.Logs())

--- a/pkg/otel/metrics/arrow/all_test.go
+++ b/pkg/otel/metrics/arrow/all_test.go
@@ -637,7 +637,7 @@ func TestMetrics(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		sb, err := NewMetricsBuilder(rBuilder)
+		sb, err := NewMetricsBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer sb.Release()
 

--- a/pkg/otel/metrics/arrow/optimizer.go
+++ b/pkg/otel/metrics/arrow/optimizer.go
@@ -18,20 +18,21 @@
 package arrow
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
+	"github.com/HdrHistogram/hdrhistogram-go"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
-	"github.com/f5/otel-arrow-adapter/pkg/benchmark/stats"
 	carrow "github.com/f5/otel-arrow-adapter/pkg/otel/common/arrow"
 	"github.com/f5/otel-arrow-adapter/pkg/otel/common/otlp"
 )
 
 type MetricsOptimizer struct {
 	sort  bool
-	stats *stats.MetricsStats
+	stats *MetricsStats
 }
 
 type MetricsOptimized struct {
@@ -53,6 +54,25 @@ type ScopeMetricsGroup struct {
 	Metrics []*pmetric.Metric
 }
 
+type MetricsStats struct {
+	MetricsCount               int
+	ResourceMetricsHistogram   *hdrhistogram.Histogram
+	ResourceAttrsHistogram     *hdrhistogram.Histogram
+	ScopeMetricsHistogram      *hdrhistogram.Histogram
+	ScopeAttrsHistogram        *hdrhistogram.Histogram
+	MetricsHistogram           *hdrhistogram.Histogram
+	SumHistogram               *hdrhistogram.Histogram
+	SumAttrsHistogram          *hdrhistogram.Histogram
+	GaugeHistogram             *hdrhistogram.Histogram
+	GaugeAttrsHistogram        *hdrhistogram.Histogram
+	HistogramHistogram         *hdrhistogram.Histogram
+	HistogramAttrsHistogram    *hdrhistogram.Histogram
+	SummaryHistogram           *hdrhistogram.Histogram
+	SummaryAttrsHistogram      *hdrhistogram.Histogram
+	ExpHistogramHistogram      *hdrhistogram.Histogram
+	ExpHistogramAttrsHistogram *hdrhistogram.Histogram
+}
+
 func NewMetricsOptimizer(cfg ...func(*carrow.Options)) *MetricsOptimizer {
 	options := carrow.Options{
 		Sort:  false,
@@ -62,15 +82,36 @@ func NewMetricsOptimizer(cfg ...func(*carrow.Options)) *MetricsOptimizer {
 		c(&options)
 	}
 
-	var s *stats.MetricsStats
+	var s *MetricsStats
 	if options.Stats {
-		s = stats.NewMetricsStats()
+		s = &MetricsStats{
+			MetricsCount:               0,
+			ResourceMetricsHistogram:   hdrhistogram.New(1, 1000000, 1),
+			ResourceAttrsHistogram:     hdrhistogram.New(1, 1000000, 1),
+			ScopeMetricsHistogram:      hdrhistogram.New(1, 1000000, 1),
+			ScopeAttrsHistogram:        hdrhistogram.New(1, 1000000, 1),
+			MetricsHistogram:           hdrhistogram.New(1, 1000000, 1),
+			SumHistogram:               hdrhistogram.New(1, 1000000, 1),
+			SumAttrsHistogram:          hdrhistogram.New(1, 1000000, 1),
+			GaugeHistogram:             hdrhistogram.New(1, 1000000, 1),
+			GaugeAttrsHistogram:        hdrhistogram.New(1, 1000000, 1),
+			HistogramHistogram:         hdrhistogram.New(1, 1000000, 1),
+			HistogramAttrsHistogram:    hdrhistogram.New(1, 1000000, 1),
+			SummaryHistogram:           hdrhistogram.New(1, 1000000, 1),
+			SummaryAttrsHistogram:      hdrhistogram.New(1, 1000000, 1),
+			ExpHistogramHistogram:      hdrhistogram.New(1, 1000000, 1),
+			ExpHistogramAttrsHistogram: hdrhistogram.New(1, 1000000, 1),
+		}
 	}
 
 	return &MetricsOptimizer{
 		sort:  options.Sort,
 		stats: s,
 	}
+}
+
+func (t *MetricsOptimizer) Stats() *MetricsStats {
+	return t.stats
 }
 
 func (t *MetricsOptimizer) Optimize(metrics pmetric.Metrics) *MetricsOptimized {
@@ -91,7 +132,25 @@ func (t *MetricsOptimizer) Optimize(metrics pmetric.Metrics) *MetricsOptimized {
 		}
 	}
 
+	if t.stats != nil {
+		metricsOptimized.RecordStats(t.stats)
+	}
+
 	return metricsOptimized
+}
+
+func (t *MetricsOptimized) RecordStats(stats *MetricsStats) {
+	stats.MetricsCount++
+	if err := stats.ResourceMetricsHistogram.RecordValue(int64(len(t.ResourceMetrics))); err != nil {
+		panic(fmt.Sprintf("number of resource metrics is out of range: %v", err))
+	}
+	for _, resMetricsGroup := range t.ResourceMetrics {
+		attrs := resMetricsGroup.Resource.Attributes()
+		if err := stats.ResourceAttrsHistogram.RecordValue(int64(attrs.Len())); err != nil {
+			panic(fmt.Sprintf("number of resource attrs is out of range: %v", err))
+		}
+		resMetricsGroup.RecordStats(stats)
+	}
 }
 
 func (t *MetricsOptimized) AddResourceMetrics(resMetrics *pmetric.ResourceMetrics) {
@@ -133,8 +192,8 @@ func (r *ResourceMetricsGroup) AddScopeMetrics(scopeMetrics *pmetric.ScopeMetric
 	metricsSlice := scopeMetrics.Metrics()
 	for i := 0; i < metricsSlice.Len(); i++ {
 		metric := metricsSlice.At(i)
-		scopeMetrics := r.ScopeMetrics[scopeMetricsGroupIdx]
-		scopeMetrics.Metrics = append(scopeMetrics.Metrics, &metric)
+		sm := r.ScopeMetrics[scopeMetricsGroupIdx]
+		sm.Metrics = append(sm.Metrics, &metric)
 	}
 }
 
@@ -147,4 +206,221 @@ func (r *ResourceMetricsGroup) Sort() {
 			) == -1
 		})
 	}
+}
+
+func (t *ResourceMetricsGroup) RecordStats(stats *MetricsStats) {
+	if err := stats.ScopeMetricsHistogram.RecordValue(int64(len(t.ScopeMetrics))); err != nil {
+		panic(fmt.Sprintf("number of scope metrics is out of range: %v", err))
+	}
+	for _, scopeMetricsGroup := range t.ScopeMetrics {
+		attrs := scopeMetricsGroup.Scope.Attributes()
+		if err := stats.ScopeAttrsHistogram.RecordValue(int64(attrs.Len())); err != nil {
+			panic(fmt.Sprintf("number of scope attributes is out of range: %v", err))
+		}
+		scopeMetricsGroup.RecordStats(stats)
+	}
+}
+
+func (t *ScopeMetricsGroup) RecordStats(stats *MetricsStats) {
+	if err := stats.MetricsHistogram.RecordValue(int64(len(t.Metrics))); err != nil {
+		panic(fmt.Sprintf("number of metrics is out of range: %v", err))
+	}
+
+	sumCount := 0
+	gaugeCount := 0
+	summaryCount := 0
+	histogramCount := 0
+	expHistogramCount := 0
+
+	for _, metric := range t.Metrics {
+		switch metric.Type() {
+		case pmetric.MetricTypeSum:
+			dps := metric.Sum().DataPoints()
+			for i := 0; i < dps.Len(); i++ {
+				dp := dps.At(i)
+				if err := stats.SumAttrsHistogram.RecordValue(int64(dp.Attributes().Len())); err != nil {
+					panic(fmt.Sprintf("number of sum attributes is out of range: %v", err))
+				}
+			}
+			sumCount++
+		case pmetric.MetricTypeGauge:
+			dps := metric.Gauge().DataPoints()
+			for i := 0; i < dps.Len(); i++ {
+				dp := dps.At(i)
+				if err := stats.GaugeAttrsHistogram.RecordValue(int64(dp.Attributes().Len())); err != nil {
+					panic(fmt.Sprintf("number of gauge attributes is out of range: %v", err))
+				}
+			}
+			gaugeCount++
+		case pmetric.MetricTypeSummary:
+			dps := metric.Summary().DataPoints()
+			for i := 0; i < dps.Len(); i++ {
+				dp := dps.At(i)
+				if err := stats.SummaryAttrsHistogram.RecordValue(int64(dp.Attributes().Len())); err != nil {
+					panic(fmt.Sprintf("number of summary attributes is out of range: %v", err))
+				}
+			}
+			summaryCount++
+		case pmetric.MetricTypeHistogram:
+			dps := metric.Histogram().DataPoints()
+			for i := 0; i < dps.Len(); i++ {
+				dp := dps.At(i)
+				if err := stats.HistogramAttrsHistogram.RecordValue(int64(dp.Attributes().Len())); err != nil {
+					panic(fmt.Sprintf("number of histogram attributes is out of range: %v", err))
+				}
+			}
+			histogramCount++
+		case pmetric.MetricTypeExponentialHistogram:
+			dps := metric.ExponentialHistogram().DataPoints()
+			for i := 0; i < dps.Len(); i++ {
+				dp := dps.At(i)
+				if err := stats.ExpHistogramAttrsHistogram.RecordValue(int64(dp.Attributes().Len())); err != nil {
+					panic(fmt.Sprintf("number of exponential histogram attributes is out of range: %v", err))
+				}
+			}
+			expHistogramCount++
+		default: /* ignore */
+		}
+	}
+
+	if err := stats.SumHistogram.RecordValue(int64(sumCount)); err != nil {
+		panic(fmt.Sprintf("number of sum metrics is out of range: %v", err))
+	}
+	if err := stats.GaugeHistogram.RecordValue(int64(gaugeCount)); err != nil {
+		panic(fmt.Sprintf("number of gauge metrics is out of range: %v", err))
+	}
+	if err := stats.SummaryHistogram.RecordValue(int64(summaryCount)); err != nil {
+		panic(fmt.Sprintf("number of summary metrics is out of range: %v", err))
+	}
+	if err := stats.HistogramHistogram.RecordValue(int64(histogramCount)); err != nil {
+		panic(fmt.Sprintf("number of histogram metrics is out of range: %v", err))
+	}
+	if err := stats.ExpHistogramHistogram.RecordValue(int64(expHistogramCount)); err != nil {
+		panic(fmt.Sprintf("number of exponential histogram metrics is out of range: %v", err))
+	}
+}
+
+func (t *MetricsStats) Show() {
+	println("\nMetrics stats (after optimization):")
+	fmt.Printf("\tNumber of metric batches   : %d\n", t.MetricsCount)
+	fmt.Printf("\tResource metrics/Batch     : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.ResourceMetricsHistogram.Mean(),
+		t.ResourceMetricsHistogram.Min(),
+		t.ResourceMetricsHistogram.Max(),
+		t.ResourceMetricsHistogram.StdDev(),
+		t.ResourceMetricsHistogram.ValueAtQuantile(50),
+		t.ResourceMetricsHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tAttributes/Resource        : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.ResourceAttrsHistogram.Mean(),
+		t.ResourceAttrsHistogram.Min(),
+		t.ResourceAttrsHistogram.Max(),
+		t.ResourceAttrsHistogram.StdDev(),
+		t.ResourceAttrsHistogram.ValueAtQuantile(50),
+		t.ResourceAttrsHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tScope metrics/Resource     : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.ScopeMetricsHistogram.Mean(),
+		t.ScopeMetricsHistogram.Min(),
+		t.ScopeMetricsHistogram.Max(),
+		t.ScopeMetricsHistogram.StdDev(),
+		t.ScopeMetricsHistogram.ValueAtQuantile(50),
+		t.ScopeMetricsHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tAttributes/Scope           : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.ScopeAttrsHistogram.Mean(),
+		t.ScopeAttrsHistogram.Min(),
+		t.ScopeAttrsHistogram.Max(),
+		t.ScopeAttrsHistogram.StdDev(),
+		t.ScopeAttrsHistogram.ValueAtQuantile(50),
+		t.ScopeAttrsHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tNumber of metrics/Scope    : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.MetricsHistogram.Mean(),
+		t.MetricsHistogram.Min(),
+		t.MetricsHistogram.Max(),
+		t.MetricsHistogram.StdDev(),
+		t.MetricsHistogram.ValueAtQuantile(50),
+		t.MetricsHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tSum metrics/Scope          : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.SumHistogram.Mean(),
+		t.SumHistogram.Min(),
+		t.SumHistogram.Max(),
+		t.SumHistogram.StdDev(),
+		t.SumHistogram.ValueAtQuantile(50),
+		t.SumHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tAttributes/Sum             : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.SumAttrsHistogram.Mean(),
+		t.SumAttrsHistogram.Min(),
+		t.SumAttrsHistogram.Max(),
+		t.SumAttrsHistogram.StdDev(),
+		t.SumAttrsHistogram.ValueAtQuantile(50),
+		t.SumAttrsHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tGauge metrics/Scope        : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.GaugeHistogram.Mean(),
+		t.GaugeHistogram.Min(),
+		t.GaugeHistogram.Max(),
+		t.GaugeHistogram.StdDev(),
+		t.GaugeHistogram.ValueAtQuantile(50),
+		t.GaugeHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tAttributes/Gauge           : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.GaugeAttrsHistogram.Mean(),
+		t.GaugeAttrsHistogram.Min(),
+		t.GaugeAttrsHistogram.Max(),
+		t.GaugeAttrsHistogram.StdDev(),
+		t.GaugeAttrsHistogram.ValueAtQuantile(50),
+		t.GaugeAttrsHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tSummary metrics/Scope      : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.SummaryHistogram.Mean(),
+		t.SummaryHistogram.Min(),
+		t.SummaryHistogram.Max(),
+		t.SummaryHistogram.StdDev(),
+		t.SummaryHistogram.ValueAtQuantile(50),
+		t.SummaryHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tAttributes/Summary         : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.SummaryAttrsHistogram.Mean(),
+		t.SummaryAttrsHistogram.Min(),
+		t.SummaryAttrsHistogram.Max(),
+		t.SummaryAttrsHistogram.StdDev(),
+		t.SummaryAttrsHistogram.ValueAtQuantile(50),
+		t.SummaryAttrsHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tHistogram metrics/Scope    : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.HistogramHistogram.Mean(),
+		t.HistogramHistogram.Min(),
+		t.HistogramHistogram.Max(),
+		t.HistogramHistogram.StdDev(),
+		t.HistogramHistogram.ValueAtQuantile(50),
+		t.HistogramHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tAttributes/Histogram       : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.HistogramAttrsHistogram.Mean(),
+		t.HistogramAttrsHistogram.Min(),
+		t.HistogramAttrsHistogram.Max(),
+		t.HistogramAttrsHistogram.StdDev(),
+		t.HistogramAttrsHistogram.ValueAtQuantile(50),
+		t.HistogramAttrsHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tExp Histogram metrics/Scope: mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.ExpHistogramHistogram.Mean(),
+		t.ExpHistogramHistogram.Min(),
+		t.ExpHistogramHistogram.Max(),
+		t.ExpHistogramHistogram.StdDev(),
+		t.ExpHistogramHistogram.ValueAtQuantile(50),
+		t.ExpHistogramHistogram.ValueAtQuantile(99),
+	)
+	fmt.Printf("\tAttributes/Exp Histogram   : mean: %8.2f, min: %8d, max: %8d, std-dev: %8.2f, p50: %8d, p99: %8d\n",
+		t.ExpHistogramAttrsHistogram.Mean(),
+		t.ExpHistogramAttrsHistogram.Min(),
+		t.ExpHistogramAttrsHistogram.Max(),
+		t.ExpHistogramAttrsHistogram.StdDev(),
+		t.ExpHistogramAttrsHistogram.ValueAtQuantile(50),
+		t.ExpHistogramAttrsHistogram.ValueAtQuantile(99),
+	)
 }

--- a/pkg/otel/metrics/otlp/metrics_test.go
+++ b/pkg/otel/metrics/otlp/metrics_test.go
@@ -50,7 +50,7 @@ func TestMetrics(t *testing.T) {
 
 	// Create Arrow record from OTLP metrics.
 	for {
-		b, err := ametrics.NewMetricsBuilder(rBuilder)
+		b, err := ametrics.NewMetricsBuilder(rBuilder, false)
 		require.NoError(t, err)
 		for i := 0; i < maxIter; i++ {
 			err = b.Append(internal.Metrics1())

--- a/pkg/otel/metrics/validation_test.go
+++ b/pkg/otel/metrics/validation_test.go
@@ -71,7 +71,7 @@ func TestBackAndForthConversion(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		lb, err := ametrics.NewMetricsBuilder(rBuilder)
+		lb, err := ametrics.NewMetricsBuilder(rBuilder, false)
 		require.NoError(t, err)
 
 		err = lb.Append(expectedRequest.Metrics())

--- a/pkg/otel/traces/arrow/all_test.go
+++ b/pkg/otel/traces/arrow/all_test.go
@@ -342,7 +342,7 @@ func TestTraces(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		tb, err := NewTracesBuilder(rBuilder)
+		tb, err := NewTracesBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer tb.Release()
 

--- a/pkg/otel/traces/arrow/empty_trace_test.go
+++ b/pkg/otel/traces/arrow/empty_trace_test.go
@@ -40,7 +40,7 @@ func TestEmptyTrace(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		b, err := NewTracesBuilder(rBuilder)
+		b, err := NewTracesBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer b.Release()
 
@@ -72,7 +72,7 @@ func TestEmptyResource(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		b, err := NewTracesBuilder(rBuilder)
+		b, err := NewTracesBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer b.Release()
 
@@ -107,7 +107,7 @@ func TestEmptyResourceAttribute(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		b, err := NewTracesBuilder(rBuilder)
+		b, err := NewTracesBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer b.Release()
 
@@ -143,7 +143,7 @@ func TestEmptyScopeSpan(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		b, err := NewTracesBuilder(rBuilder)
+		b, err := NewTracesBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer b.Release()
 
@@ -179,7 +179,7 @@ func TestEmptyScope(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		b, err := NewTracesBuilder(rBuilder)
+		b, err := NewTracesBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer b.Release()
 
@@ -216,7 +216,7 @@ func TestEmptyScopeAttribute(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		b, err := NewTracesBuilder(rBuilder)
+		b, err := NewTracesBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer b.Release()
 
@@ -254,7 +254,7 @@ func TestEmptySpans(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		b, err := NewTracesBuilder(rBuilder)
+		b, err := NewTracesBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer b.Release()
 
@@ -290,7 +290,7 @@ func TestEmptySpanAttribute(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		b, err := NewTracesBuilder(rBuilder)
+		b, err := NewTracesBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer b.Release()
 
@@ -328,7 +328,7 @@ func TestEmptySpanStatus(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		b, err := NewTracesBuilder(rBuilder)
+		b, err := NewTracesBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer b.Release()
 
@@ -366,7 +366,7 @@ func TestEmptySpanLink(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		b, err := NewTracesBuilder(rBuilder)
+		b, err := NewTracesBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer b.Release()
 
@@ -404,7 +404,7 @@ func TestEmptySpanEvent(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		b, err := NewTracesBuilder(rBuilder)
+		b, err := NewTracesBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer b.Release()
 

--- a/pkg/otel/traces/arrow/traces.go
+++ b/pkg/otel/traces/arrow/traces.go
@@ -46,11 +46,19 @@ type TracesBuilder struct {
 }
 
 // NewTracesBuilder creates a new TracesBuilder with a given allocator.
-func NewTracesBuilder(rBuilder *builder.RecordBuilderExt) (*TracesBuilder, error) {
+func NewTracesBuilder(rBuilder *builder.RecordBuilderExt, traceStats bool) (*TracesBuilder, error) {
+	var optimizer *TracesOptimizer
+
+	if traceStats {
+		optimizer = NewTracesOptimizer(acommon.WithStats())
+	} else {
+		optimizer = NewTracesOptimizer()
+	}
+
 	tracesBuilder := &TracesBuilder{
 		released:  false,
 		builder:   rBuilder,
-		optimizer: NewTracesOptimizer(),
+		optimizer: optimizer,
 	}
 	if err := tracesBuilder.init(); err != nil {
 		return nil, werror.Wrap(err)
@@ -63,6 +71,10 @@ func (b *TracesBuilder) init() error {
 	b.rsb = rsb
 	b.rsp = ResourceSpansBuilderFrom(rsb.StructBuilder())
 	return nil
+}
+
+func (b *TracesBuilder) Stats() *TracesStats {
+	return b.optimizer.Stats()
 }
 
 // Build builds an Arrow Record from the builder.

--- a/pkg/otel/traces/validation_test.go
+++ b/pkg/otel/traces/validation_test.go
@@ -63,7 +63,7 @@ func TestConversionFromSyntheticData(t *testing.T) {
 	var record arrow.Record
 
 	for {
-		tb, err := tracesarrow.NewTracesBuilder(rBuilder)
+		tb, err := tracesarrow.NewTracesBuilder(rBuilder, false)
 		require.NoError(t, err)
 		defer tb.Release()
 		err = tb.Append(expectedRequest.Traces())
@@ -118,7 +118,7 @@ func checkTracesConversion(t *testing.T, expectedRequest ptraceotlp.ExportReques
 	var record arrow.Record
 
 	for {
-		tb, err := tracesarrow.NewTracesBuilder(rBuilder)
+		tb, err := tracesarrow.NewTracesBuilder(rBuilder, false)
 		require.NoError(t, err)
 		err = tb.Append(expectedRequest.Traces())
 		require.NoError(t, err)

--- a/tools/trace_benchmark/main.go
+++ b/tools/trace_benchmark/main.go
@@ -52,7 +52,7 @@ func main() {
 	// Compare the performance for each input file
 	for i := range inputFiles {
 		// Compare the performance between the standard OTLP representation and the OTLP Arrow representation.
-		profiler := benchmark.NewProfiler([]int{ /*10, 100, 1000, 2000,*/ 5000, 10000}, "output/trace_benchmark.log", 2)
+		profiler := benchmark.NewProfiler([]int{10, 100, 1000, 2000, 5000, 10000}, "output/trace_benchmark.log", 2)
 		//profiler := benchmark.NewProfiler([]int{1000}, "output/trace_benchmark.log", 2)
 		compressionAlgo := benchmark.Zstd()
 		maxIter := uint64(1)


### PR DESCRIPTION
Example of statistics generated for traces.
![image](https://user-images.githubusercontent.com/657994/228684749-cf360fc8-4f9a-42a1-8d2e-e4c2e6b36070.png)

Similar statistics exist for metrics and logs.

Options have been added to the `Producer` to enable the stats recording per OTel object. By default the stats recording is not enabled.

Memory consumption: ~2244 bytes/histogram 