### PR TITLE
Arrow receiver: enabled by default

### DIFF
--- a/collector/gen/receiver/otlpreceiver/config.go
+++ b/collector/gen/receiver/otlpreceiver/config.go
@@ -36,9 +36,9 @@ type Protocols struct {
 	Arrow *ArrowSettings                 `mapstructure:"arrow"`
 }
 
-// ArrowSettings
+// ArrowSettings support disabling the Arrow receiver.
 type ArrowSettings struct {
-	Enabled bool `mapstructure:"enabled"`
+	Disabled bool `mapstructure:"disabled"`
 }
 
 // Config defines configuration for OTLP receiver.
@@ -55,7 +55,7 @@ func (cfg *Config) Validate() error {
 	if cfg.GRPC == nil && cfg.HTTP == nil {
 		return errors.New("must specify at least one protocol when using the OTLP receiver")
 	}
-	if cfg.Arrow != nil && cfg.Arrow.Enabled && cfg.GRPC == nil {
+	if cfg.Arrow != nil && !cfg.Arrow.Disabled && cfg.GRPC == nil {
 		return errors.New("must specify at gRPC protocol when using the OTLP+Arrow receiver")
 	}
 	return nil

--- a/collector/gen/receiver/otlpreceiver/config_test.go
+++ b/collector/gen/receiver/otlpreceiver/config_test.go
@@ -140,7 +140,7 @@ func TestUnmarshalConfig(t *testing.T) {
 					},
 				},
 				Arrow: &ArrowSettings{
-					Enabled: true,
+					Disabled: false,
 				},
 			},
 		}, cfg)
@@ -167,9 +167,7 @@ func TestUnmarshalConfigUnix(t *testing.T) {
 					Endpoint: "/tmp/http_otlp.sock",
 					// Transport: "unix",
 				},
-				Arrow: &ArrowSettings{
-					Enabled: false,
-				},
+				Arrow: &ArrowSettings{},
 			},
 		}, cfg)
 }

--- a/collector/gen/receiver/otlpreceiver/factory.go
+++ b/collector/gen/receiver/otlpreceiver/factory.go
@@ -17,12 +17,12 @@ package otlpreceiver // import "github.com/f5/otel-arrow-adapter/collector/gen/r
 import (
 	"context"
 
+	"github.com/f5/otel-arrow-adapter/collector/gen/internal/sharedcomponent"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/consumer"
-	"github.com/f5/otel-arrow-adapter/collector/gen/internal/sharedcomponent"
 	"go.opentelemetry.io/collector/receiver"
 )
 
@@ -59,7 +59,7 @@ func createDefaultConfig() component.Config {
 				Endpoint: defaultHTTPEndpoint,
 			},
 			Arrow: &ArrowSettings{
-				Enabled: false,
+				Disabled: false,
 			},
 		},
 	}

--- a/collector/gen/receiver/otlpreceiver/factory_test.go
+++ b/collector/gen/receiver/otlpreceiver/factory_test.go
@@ -21,13 +21,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/f5/otel-arrow-adapter/collector/gen/internal/testutil"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
-	"github.com/f5/otel-arrow-adapter/collector/gen/internal/testutil"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
@@ -43,7 +43,7 @@ func TestCreateReceiver(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPC.NetAddr.Endpoint = testutil.GetAvailableLocalAddress(t)
 	cfg.HTTP.Endpoint = testutil.GetAvailableLocalAddress(t)
-	cfg.Arrow.Enabled = true
+	cfg.Arrow.Disabled = false
 
 	creationSet := receivertest.NewNopCreateSettings()
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())

--- a/collector/gen/receiver/otlpreceiver/otlp.go
+++ b/collector/gen/receiver/otlpreceiver/otlp.go
@@ -27,21 +27,21 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
+	"github.com/f5/otel-arrow-adapter/collector/gen/internal/netstats"
+	"github.com/f5/otel-arrow-adapter/collector/gen/receiver/otlpreceiver/internal/arrow"
+	"github.com/f5/otel-arrow-adapter/collector/gen/receiver/otlpreceiver/internal/logs"
+	"github.com/f5/otel-arrow-adapter/collector/gen/receiver/otlpreceiver/internal/metrics"
+	"github.com/f5/otel-arrow-adapter/collector/gen/receiver/otlpreceiver/internal/trace"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/extension/auth"
-	"github.com/f5/otel-arrow-adapter/collector/gen/internal/netstats"
 	"go.opentelemetry.io/collector/obsreport"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"go.opentelemetry.io/collector/receiver"
-	"github.com/f5/otel-arrow-adapter/collector/gen/receiver/otlpreceiver/internal/arrow"
-	"github.com/f5/otel-arrow-adapter/collector/gen/receiver/otlpreceiver/internal/logs"
-	"github.com/f5/otel-arrow-adapter/collector/gen/receiver/otlpreceiver/internal/metrics"
-	"github.com/f5/otel-arrow-adapter/collector/gen/receiver/otlpreceiver/internal/trace"
 )
 
 // otlpReceiver is the type that exposes Trace and Metrics reception.
@@ -162,7 +162,7 @@ func (r *otlpReceiver) startProtocolServers(host component.Host) error {
 			plogotlp.RegisterGRPCServer(r.serverGRPC, r.logsReceiver)
 		}
 
-		if r.cfg.Arrow != nil && r.cfg.Arrow.Enabled {
+		if r.cfg.Arrow != nil && !r.cfg.Arrow.Disabled {
 			var authServer auth.Server
 			if r.cfg.GRPC.Auth != nil {
 				authServer, err = r.cfg.GRPC.Auth.GetServerAuthenticator(host.GetExtensions())

--- a/collector/gen/receiver/otlpreceiver/otlp_test.go
+++ b/collector/gen/receiver/otlpreceiver/otlp_test.go
@@ -42,6 +42,9 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/f5/otel-arrow-adapter/collector/gen/internal/testdata"
+	"github.com/f5/otel-arrow-adapter/collector/gen/internal/testutil"
+	"github.com/f5/otel-arrow-adapter/collector/gen/receiver/otlpreceiver/internal/arrow/mock"
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -54,14 +57,11 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/extension/auth"
-	"github.com/f5/otel-arrow-adapter/collector/gen/internal/testdata"
-	"github.com/f5/otel-arrow-adapter/collector/gen/internal/testutil"
 	"go.opentelemetry.io/collector/obsreport/obsreporttest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"go.opentelemetry.io/collector/receiver"
-	"github.com/f5/otel-arrow-adapter/collector/gen/receiver/otlpreceiver/internal/arrow/mock"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
 )
@@ -1135,7 +1135,7 @@ func TestGRPCArrowReceiver(t *testing.T) {
 	cfg.GRPC.NetAddr.Endpoint = addr
 	cfg.GRPC.IncludeMetadata = true
 	cfg.HTTP = nil
-	cfg.Arrow.Enabled = true
+	cfg.Arrow.Disabled = false
 	id := component.NewID("arrow")
 	ocr := newReceiver(t, factory, cfg, id, sink, nil)
 
@@ -1248,7 +1248,7 @@ func TestGRPCArrowReceiverAuth(t *testing.T) {
 		AuthenticatorID: authID,
 	}
 	cfg.HTTP = nil
-	cfg.Arrow.Enabled = true
+	cfg.Arrow.Disabled = false
 	id := component.NewID("arrow")
 	ocr := newReceiver(t, factory, cfg, id, sink, nil)
 

--- a/collector/gen/receiver/otlpreceiver/testdata/arrow_without_grpc.yaml
+++ b/collector/gen/receiver/otlpreceiver/testdata/arrow_without_grpc.yaml
@@ -2,4 +2,3 @@
 protocols:
   http:
   arrow:
-    enabled: true

--- a/collector/gen/receiver/otlpreceiver/testdata/config.yaml
+++ b/collector/gen/receiver/otlpreceiver/testdata/config.yaml
@@ -41,4 +41,4 @@ protocols:
       max_age: 7200
   # Arrow enables receiving OTLP+Arrow streaming
   arrow:
-    enabled: true
+    disabled: false


### PR DESCRIPTION
As a stand-alone component, the Arrow receiver should be enabled by default.