### PR TITLE
Arrow exporter: enabled by default w/ NumCPU streams

### DIFF
--- a/collector/gen/exporter/otlpexporter/config.go
+++ b/collector/gen/exporter/otlpexporter/config.go
@@ -36,7 +36,7 @@ type Config struct {
 // ArrowSettings includes whether Arrow is enabled and the number of
 // concurrent Arrow streams.
 type ArrowSettings struct {
-	Enabled          bool `mapstructure:"enabled"`
+	Disabled         bool `mapstructure:"disabled"`
 	NumStreams       int  `mapstructure:"num_streams"`
 	DisableDowngrade bool `mapstructure:"disable_downgrade"`
 }

--- a/collector/gen/exporter/otlpexporter/config_test.go
+++ b/collector/gen/exporter/otlpexporter/config_test.go
@@ -88,7 +88,6 @@ func TestUnmarshalConfig(t *testing.T) {
 				Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("nop")},
 			},
 			Arrow: ArrowSettings{
-				Enabled:    true,
 				NumStreams: 2,
 			},
 		}, cfg)
@@ -96,7 +95,7 @@ func TestUnmarshalConfig(t *testing.T) {
 
 func TestArrowSettingsValidate(t *testing.T) {
 	settings := func(enabled bool, numStreams int) *ArrowSettings {
-		return &ArrowSettings{Enabled: enabled, NumStreams: numStreams}
+		return &ArrowSettings{Disabled: !enabled, NumStreams: numStreams}
 	}
 	require.NoError(t, settings(true, 1).Validate())
 	require.NoError(t, settings(false, 1).Validate())

--- a/collector/gen/exporter/otlpexporter/factory.go
+++ b/collector/gen/exporter/otlpexporter/factory.go
@@ -16,6 +16,7 @@ package otlpexporter // import "github.com/f5/otel-arrow-adapter/collector/gen/e
 
 import (
 	"context"
+	"runtime"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcompression"
@@ -55,8 +56,7 @@ func createDefaultConfig() component.Config {
 			WriteBufferSize: 512 * 1024,
 		},
 		Arrow: ArrowSettings{
-			NumStreams: 1,
-			Enabled:    false,
+			NumStreams: runtime.NumCPU(),
 		},
 	}
 }

--- a/collector/gen/exporter/otlpexporter/factory_test.go
+++ b/collector/gen/exporter/otlpexporter/factory_test.go
@@ -17,12 +17,14 @@ package otlpexporter
 import (
 	"context"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/f5/otel-arrow-adapter/collector/gen/internal/testutil"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configcompression"
 	"go.opentelemetry.io/collector/config/configgrpc"
@@ -30,7 +32,6 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/exportertest"
-	"github.com/f5/otel-arrow-adapter/collector/gen/internal/testutil"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -44,7 +45,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.Equal(t, ocfg.QueueSettings, exporterhelper.NewDefaultQueueSettings())
 	assert.Equal(t, ocfg.TimeoutSettings, exporterhelper.NewDefaultTimeoutSettings())
 	assert.Equal(t, ocfg.Compression, configcompression.Gzip)
-	assert.Equal(t, ocfg.Arrow, ArrowSettings{Enabled: false, NumStreams: 1})
+	assert.Equal(t, ocfg.Arrow, ArrowSettings{Disabled: false, NumStreams: runtime.NumCPU()})
 }
 
 func TestCreateMetricsExporter(t *testing.T) {
@@ -228,7 +229,6 @@ func TestCreateArrowTracesExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.GRPCClientSettings.Endpoint = testutil.GetAvailableLocalAddress(t)
 	cfg.Arrow = ArrowSettings{
-		Enabled:    true,
 		NumStreams: 1,
 	}
 	set := exportertest.NewNopCreateSettings()

--- a/collector/gen/exporter/otlpexporter/otlp.go
+++ b/collector/gen/exporter/otlpexporter/otlp.go
@@ -32,12 +32,12 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/f5/otel-arrow-adapter/collector/gen/exporter/otlpexporter/internal/arrow"
+	"github.com/f5/otel-arrow-adapter/collector/gen/internal/netstats"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	"github.com/f5/otel-arrow-adapter/collector/gen/exporter/otlpexporter/internal/arrow"
-	"github.com/f5/otel-arrow-adapter/collector/gen/internal/netstats"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -83,7 +83,7 @@ func newExporter(cfg component.Config, set exporter.CreateSettings) (*baseExport
 	userAgent := fmt.Sprintf("%s/%s (%s/%s)",
 		set.BuildInfo.Description, set.BuildInfo.Version, runtime.GOOS, runtime.GOARCH)
 
-	if oCfg.Arrow.Enabled {
+	if !oCfg.Arrow.Disabled {
 		userAgent += fmt.Sprintf(" ApacheArrow/%s (NumStreams/%d)", arrowPkg.PkgVersion, oCfg.Arrow.NumStreams)
 	}
 
@@ -114,7 +114,7 @@ func (e *baseExporter) start(ctx context.Context, host component.Host) (err erro
 		grpc.WaitForReady(e.config.GRPCClientSettings.WaitForReady),
 	}
 
-	if e.config.Arrow.Enabled {
+	if !e.config.Arrow.Disabled {
 		// Note this sets static outgoing context for all future stream requests.
 		ctx := e.enhanceContext(context.Background())
 

--- a/collector/gen/exporter/otlpexporter/testdata/config.yaml
+++ b/collector/gen/exporter/otlpexporter/testdata/config.yaml
@@ -27,4 +27,4 @@ keepalive:
 balancer_name: "round_robin"
 arrow:
   num_streams: 2
-  enabled: true
+  disabled: false


### PR DESCRIPTION
As a stand-alone component, the Arrow exporter should be enabled by default and use NumCPU streams.