### PR TITLE
Add the RPC method name to the netstats counters

### DIFF
--- a/collector/gen/internal/netstats/handler.go
+++ b/collector/gen/internal/netstats/handler.go
@@ -20,13 +20,19 @@ import (
 	"google.golang.org/grpc/stats"
 )
 
+type netstatsContext struct{}
+
 // TagRPC implements grpc/stats.Handler
-func (rep *NetworkReporter) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
-	return ctx
+func (rep *NetworkReporter) TagRPC(ctx context.Context, s *stats.RPCTagInfo) context.Context {
+	return context.WithValue(ctx, netstatsContext{}, s.FullMethodName)
 }
 
 // HandleRPC implements grpc/stats.Handler
 func (rep *NetworkReporter) HandleRPC(ctx context.Context, rs stats.RPCStats) {
+	method := "unknown"
+	if name := ctx.Value(netstatsContext{}); name != nil {
+		method = name.(string)
+	}
 	switch s := rs.(type) {
 	case *stats.Begin, *stats.OutHeader, *stats.OutTrailer, *stats.InHeader, *stats.InTrailer:
 		// Note we have some info about header WireLength,
@@ -34,12 +40,14 @@ func (rep *NetworkReporter) HandleRPC(ctx context.Context, rs stats.RPCStats) {
 
 	case *stats.InPayload:
 		var ss SizesStruct
+		ss.Method = method
 		ss.Length = int64(s.Length)
 		ss.WireLength = int64(s.WireLength)
 		rep.CountReceive(ctx, ss)
 
 	case *stats.OutPayload:
 		var ss SizesStruct
+		ss.Method = method
 		ss.Length = int64(s.Length)
 		ss.WireLength = int64(s.WireLength)
 		rep.CountSend(ctx, ss)


### PR DESCRIPTION
Part of https://github.com/f5/otel-arrow-adapter/issues/119

Adds a `method` attribute to the counters in collector/gen/internal/netstats. This will help us know when downgrades are happening, for example.