### PR TITLE
[issue-192] obfuscation of nested slices and maps

### DIFF
--- a/collector/processor/obfuscationprocessor/processor.go
+++ b/collector/processor/obfuscationprocessor/processor.go
@@ -166,7 +166,7 @@ func (o *obfuscation) processEventAndLinkAttrs(ctx context.Context, span ptrace.
 	}
 }
 
-func (o *obfuscation) obfSlice(ctx context.Context, slice pcommon.Slice) {
+func (o *obfuscation) processSliceValue(ctx context.Context, slice pcommon.Slice) {
 	cpy := pcommon.NewSlice()
 	for i := 0; i < slice.Len(); i++ {
 		cpyVal := cpy.AppendEmpty()
@@ -177,7 +177,7 @@ func (o *obfuscation) obfSlice(ctx context.Context, slice pcommon.Slice) {
 			cpyVal.SetStr(o.encryptString(val.Str()))
 		case pcommon.ValueTypeSlice:
 			cpySlice := cpyVal.SetEmptySlice()
-			o.obfSlice(ctx, val.Slice())
+			o.processSliceValue(ctx, val.Slice())
 			val.Slice().CopyTo(cpySlice)
 		case pcommon.ValueTypeMap:
 			cpyMap := cpyVal.SetEmptyMap()
@@ -210,7 +210,7 @@ func (o *obfuscation) processAttrs(ctx context.Context, attributes pcommon.Map) 
 			cpy.PutStr(o.encryptString(k), o.encryptString(value.Str()))
 		case pcommon.ValueTypeSlice:
 			slc := cpy.PutEmptySlice(o.encryptString(k))
-			o.obfSlice(ctx, value.Slice())
+			o.processSliceValue(ctx, value.Slice())
 			value.Slice().CopyTo(slc)
 		case pcommon.ValueTypeMap:
 			mp := cpy.PutEmptyMap(o.encryptString(k))

--- a/collector/processor/obfuscationprocessor/processor.go
+++ b/collector/processor/obfuscationprocessor/processor.go
@@ -166,7 +166,7 @@ func (o *obfuscation) processEventAndLinkAttrs(ctx context.Context, span ptrace.
 	}
 }
 
-func obfSlice(slice pcommon.Slice) pcommon.Slice {
+func (o *obfuscation) obfSlice(ctx context.Context, slice pcommon.Slice) {
 	cpy := pcommon.NewSlice()
 	for i := 0; i < slice.Len(); i++ {
 		cpyVal := cpy.AppendEmpty()
@@ -175,70 +175,26 @@ func obfSlice(slice pcommon.Slice) pcommon.Slice {
 		switch val.Type() {
 		case pcommon.ValueTypeStr:
 			cpyVal.SetStr(o.encryptString(val.Str()))
-		case pcommon.ValueTypeStr:
-			obfuscated := obfSlice(val)
-			obfuscated.CopyTo(cpyVal)
+		case pcommon.ValueTypeSlice:
+			cpySlice := cpyVal.SetEmptySlice()
+			o.obfSlice(ctx, val.Slice())
+			val.Slice().CopyTo(cpySlice)
 		case pcommon.ValueTypeMap:
-			obfuscated := obfMap(val)
-			obfuscated.CopyTo(cpyVal)
-		}
+			cpyMap := cpyVal.SetEmptyMap()
+			o.processAttrs(ctx, val.Map())
+			val.Map().CopyTo(cpyMap)
 		default:
 			// no need to obfuscate types that cannot contain a string
 			val.CopyTo(cpyVal)
-
-	}
-
-	return cpy
-}
-
-func obfMap(kv pcommon.Map) pcommon.Map {
-	cpy := pcommon.NewMap()
-	kv.Range(func(k string, value pcommon.Value) bool {
-		switch value.Type() {
-		case pcommon.ValueTypeStr:
-			cpy.PutStr(o.encryptString(k), o.encryptString(value.Str()))
-		case pcommon.ValueTypeSlice:
-			slc := cpy.PutEmptySlice(o.encryptString(k))
-			obfuscated := obfSlice(value.Slice())
-			obfuscated.CopyTo(slc)
-		case pcommon.ValueTypeMap:
-			mp := cpy.PutEmptyMap(o.encryptString(k))
-			obfuscated := obfMap(value.Map())
-			obfuscated.CopyTo(mp)
-		default:
-			value.CopyTo(cpy.PutEmpty(o.encryptString(k)))
-		}
-		return true
-	})
-
-	return cpy
-}
-
-func obfAttrs(cpy pcommon.Map, k string, val pcommon.Value) pcommon.Value {
-	switch value.Type() {
-	case pcommon.ValueTypeStr:
-		cpy.PutStr(o.encryptString(k), o.encryptString(value.Str()))
-	case pcommon.ValueTypeSlice:
-		slc := cpy.PutEmptySlice(o.encryptString(k))
-		value.Slice().CopyTo(slc)
-		for i := 0; i < slc.Len(); i++ {
-			val := slc.At(i)
-
-			switch val.Type() {
-			case pcommon.ValueTypeStr:
-				val.SetStr(o.encryptString(val.Str()))
-			case pcommon.ValueTypeSlice:
-
-			default:
-				val.CopyTo(cpy.PutEmpty(o.encryptString(k)))
-			}
 		}
 
 	}
+
+	cpy.CopyTo(slice)
 }
 
 // processAttrs obfuscates the attributes of a resource span or a span
-func (o *obfuscation) processAttrs(_ context.Context, attributes pcommon.Map) {
+func (o *obfuscation) processAttrs(ctx context.Context, attributes pcommon.Map) {
 	cpy := pcommon.NewMap()
 	attributes.Range(func(k string, value pcommon.Value) bool {
 		if !o.encryptAll {
@@ -253,20 +209,14 @@ func (o *obfuscation) processAttrs(_ context.Context, attributes pcommon.Map) {
 		case pcommon.ValueTypeStr:
 			cpy.PutStr(o.encryptString(k), o.encryptString(value.Str()))
 		case pcommon.ValueTypeSlice:
-			slc := value.Slice()
-			for i := 0; i < slc.Len(); i++ {
-				val := slc.At(i)
-				switch val.Type() {
-				case pcommon.ValueTypeStr:
-					cpy.PutStr(o.encryptString(k), o.encryptString(val.Str()))
-				default:
-					val.CopyTo(cpy.PutEmpty(o.encryptString(k)))
-				}
-			}
+			slc := cpy.PutEmptySlice(o.encryptString(k))
+			o.obfSlice(ctx, value.Slice())
+			value.Slice().CopyTo(slc)
+		case pcommon.ValueTypeMap:
+			mp := cpy.PutEmptyMap(o.encryptString(k))
+			o.processAttrs(ctx, value.Map())
+			value.Map().CopyTo(mp)
 		default:
-			// TODO: This does not cover all string values, needs
-			// to be updated for StringSlice and KVList types at
-			// least.
 			value.CopyTo(cpy.PutEmpty(o.encryptString(k)))
 		}
 		return true

--- a/collector/processor/obfuscationprocessor/processor.go
+++ b/collector/processor/obfuscationprocessor/processor.go
@@ -248,11 +248,19 @@ func (o *obfuscation) Shutdown(context.Context) error {
 }
 
 func (o *obfuscation) encryptStringToBytes(source string) []byte {
-	obfuscated, _ := o.encrypt.Encrypt(source)
+	obfuscated, err := o.encrypt.Encrypt(source)
+	if err != nil {
+		o.logger.Error("failed to obfuscate bytes, returning original", zap.Error(err))
+		return []byte(source)
+	}
 	return obfuscated.Bytes()
 }
 
 func (o *obfuscation) encryptString(source string) string {
-	obfuscated, _ := o.encrypt.Encrypt(source)
+	obfuscated, err := o.encrypt.Encrypt(source)
+	if err != nil {
+		o.logger.Error("failed to obfuscate string, returning original", zap.Error(err))
+		return source
+	}
 	return obfuscated.String(true)
 }

--- a/collector/processor/obfuscationprocessor/processor_test.go
+++ b/collector/processor/obfuscationprocessor/processor_test.go
@@ -140,7 +140,7 @@ func cryptPair(o *obfuscation, k string, v pcommon.Value) pair {
 		ov, _ := o.encrypt.Encrypt(v.Str())
 		v.SetStr(ov.String(true))
 	case pcommon.ValueTypeSlice:
-		o.obfSlice(context.Background(), v.Slice())
+		o.processSliceValue(context.Background(), v.Slice())
 	case pcommon.ValueTypeMap:
 		o.processAttrs(context.Background(), v.Map())
 	default:

--- a/collector/processor/obfuscationprocessor/processor_test.go
+++ b/collector/processor/obfuscationprocessor/processor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cyrildever/feistel/common/utils/hash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -39,6 +40,26 @@ var (
 	logAttrVal = "log-attr-val-1"
 )
 
+// returns a map that has a more complicated structure to obfuscate
+func newMap() pcommon.Map {
+	kv := pcommon.NewMap()
+
+	mp := kv.PutEmptyMap("baz")
+	slc1 := mp.PutEmptySlice("foo")
+	elt1 := slc1.AppendEmpty()
+	elt1.SetStr("fooval1")
+	elt2 := slc1.AppendEmpty()
+	elt2.SetStr("fooval2")
+
+	slc2 := mp.PutEmptySlice("bar")
+	elt3 := slc2.AppendEmpty()
+	elt3.SetStr("barval1")
+	elt4 := slc2.AppendEmpty()
+	elt4.SetStr("barval2")
+
+	return kv
+}
+
 func setupSpanWithAttrs() ptrace.Traces {
 	td := ptrace.NewTraces()
 	rs := td.ResourceSpans().AppendEmpty()
@@ -51,6 +72,8 @@ func setupSpanWithAttrs() ptrace.Traces {
 	span := ss.Spans().AppendEmpty()
 	span.SetName("operationA")
 	span.Attributes().PutStr("span-attr", spanAttrVal)
+	mp := span.Attributes().PutEmptyMap("complex-span-attr")
+	newMap().CopyTo(mp)
 
 	link0 := span.Links().AppendEmpty()
 	link0.Attributes().PutStr("span-link-attr", linkAttrVal)
@@ -66,28 +89,31 @@ func validateTraceAttrs(t *testing.T, expected map[string]pair, traces ptrace.Tr
 		rs := traces.ResourceSpans().At(i)
 		val, ok := rs.Resource().Attributes().Get(expected["resource-attr"].key)
 		assert.True(t, ok)
-		assert.Equal(t, expected["resource-attr"].val, val.AsString())
+		assert.Equal(t, expected["resource-attr"].val.AsString(), val.AsString())
 
 		for j := 0; j < rs.ScopeSpans().Len(); j++ {
 			// validate scope attributes
 			ss := rs.ScopeSpans().At(j)
 			scopeVal, ok := ss.Scope().Attributes().Get(expected["scope-attr"].key)
 			assert.True(t, ok)
-			assert.Equal(t, expected["scope-attr"].val, scopeVal.AsString())
+			assert.Equal(t, expected["scope-attr"].val.AsString(), scopeVal.AsString())
 
 			for k := 0; k < ss.Spans().Len(); k++ {
 				// validate span attributes
 				span := ss.Spans().At(k)
 				val, ok := span.Attributes().Get(expected["span-attr"].key)
 				assert.True(t, ok)
-				assert.Equal(t, expected["span-attr"].val, val.AsString())
+				assert.Equal(t, expected["span-attr"].val.AsString(), val.AsString())
+				val2, ok := span.Attributes().Get(expected["complex-span-attr"].key)
+				assert.True(t, ok)
+				assert.Equal(t, expected["complex-span-attr"].val.AsString(), val2.AsString())
 
 				for h := 0; h < span.Events().Len(); h++ {
 					// validate event attributes
 					event := span.Events().At(h)
 					val, ok := event.Attributes().Get(expected["span-event-attr"].key)
 					assert.True(t, ok)
-					assert.Equal(t, expected["span-event-attr"].val, val.AsString())
+					assert.Equal(t, expected["span-event-attr"].val.AsString(), val.AsString())
 				}
 
 				for h := 0; h < span.Links().Len(); h++ {
@@ -95,7 +121,7 @@ func validateTraceAttrs(t *testing.T, expected map[string]pair, traces ptrace.Tr
 					link := span.Links().At(h)
 					val, ok := link.Attributes().Get(expected["span-link-attr"].key)
 					assert.True(t, ok)
-					assert.Equal(t, expected["span-link-attr"].val, val.AsString())
+					assert.Equal(t, expected["span-link-attr"].val.AsString(), val.AsString())
 				}
 			}
 		}
@@ -104,15 +130,24 @@ func validateTraceAttrs(t *testing.T, expected map[string]pair, traces ptrace.Tr
 
 type pair struct {
 	key string
-	val string
+	val pcommon.Value
 }
 
-func cryptPair(o *obfuscation, k, v string) pair {
+func cryptPair(o *obfuscation, k string, v pcommon.Value) pair {
 	ok, _ := o.encrypt.Encrypt(k)
-	ov, _ := o.encrypt.Encrypt(v)
+	switch v.Type() {
+	case pcommon.ValueTypeStr:
+		ov, _ := o.encrypt.Encrypt(v.Str())
+		v.SetStr(ov.String(true))
+	case pcommon.ValueTypeSlice:
+		o.obfSlice(context.Background(), v.Slice())
+	case pcommon.ValueTypeMap:
+		o.processAttrs(context.Background(), v.Map())
+	default:
+	}
 	return pair{
 		key: ok.String(true),
-		val: ov.String(true),
+		val: v,
 	}
 }
 
@@ -123,13 +158,16 @@ func TestProcessTraces(t *testing.T) {
 		encrypt:    feistel.NewFPECipher(hash.SHA_256, "some-32-byte-long-key-to-be-safe", 128),
 		encryptAll: true,
 	}
+	csVal := pcommon.NewValueMap()
+	newMap().CopyTo(csVal.SetEmptyMap())
 
 	expected := map[string]pair{
-		"resource-attr":   cryptPair(processor, resAttrKey, resAttrVal),
-		"scope-attr":      cryptPair(processor, scopeAttrKey, scopeAttrVal),
-		"span-attr":       cryptPair(processor, spanAttrKey, spanAttrVal),
-		"span-link-attr":  cryptPair(processor, spanLinkAttrKey, linkAttrVal),
-		"span-event-attr": cryptPair(processor, spanEventAttrKey, eventAttrVal),
+		"resource-attr":     cryptPair(processor, resAttrKey, pcommon.NewValueStr(resAttrVal)),
+		"scope-attr":        cryptPair(processor, scopeAttrKey, pcommon.NewValueStr(scopeAttrVal)),
+		"span-attr":         cryptPair(processor, spanAttrKey, pcommon.NewValueStr(spanAttrVal)),
+		"span-link-attr":    cryptPair(processor, spanLinkAttrKey, pcommon.NewValueStr(linkAttrVal)),
+		"span-event-attr":   cryptPair(processor, spanEventAttrKey, pcommon.NewValueStr(eventAttrVal)),
+		"complex-span-attr": cryptPair(processor, "complex-span-attr", csVal),
 	}
 
 	processedTraces, err := processor.processTraces(context.Background(), traces)
@@ -150,26 +188,36 @@ func setupMetricsWithAttrs() pmetric.Metrics {
 	gauge := metric.SetEmptyGauge()
 	gdp := gauge.DataPoints().AppendEmpty()
 	gdp.Attributes().PutStr("gauge-attr", gaugeAttrVal)
+	mp1 := gdp.Attributes().PutEmptyMap("complex-metric-attr")
+	newMap().CopyTo(mp1)
 
 	metric = sm.Metrics().AppendEmpty()
 	sum := metric.SetEmptySum()
 	sdp := sum.DataPoints().AppendEmpty()
 	sdp.Attributes().PutStr("sum-attr", sumAttrVal)
+	mp2 := sdp.Attributes().PutEmptyMap("complex-metric-attr")
+	newMap().CopyTo(mp2)
 
 	metric = sm.Metrics().AppendEmpty()
 	hist := metric.SetEmptyHistogram()
 	hdp := hist.DataPoints().AppendEmpty()
 	hdp.Attributes().PutStr("histogram-attr", histAttrVal)
+	mp3 := hdp.Attributes().PutEmptyMap("complex-metric-attr")
+	newMap().CopyTo(mp3)
 
 	metric = sm.Metrics().AppendEmpty()
 	eHist := metric.SetEmptyExponentialHistogram()
 	ehdp := eHist.DataPoints().AppendEmpty()
 	ehdp.Attributes().PutStr("exp-histogram-attr", eHistAttrVal)
+	mp4 := ehdp.Attributes().PutEmptyMap("complex-metric-attr")
+	newMap().CopyTo(mp4)
 
 	metric = sm.Metrics().AppendEmpty()
 	summary := metric.SetEmptySummary()
 	smdp := summary.DataPoints().AppendEmpty()
 	smdp.Attributes().PutStr("summary-attr", summaryAttrVal)
+	mp5 := smdp.Attributes().PutEmptyMap("complex-metric-attr")
+	newMap().CopyTo(mp5)
 
 	return md
 }
@@ -180,14 +228,14 @@ func validateMetricsAttrs(t *testing.T, expected map[string]pair, metrics pmetri
 		rm := metrics.ResourceMetrics().At(i)
 		val, ok := rm.Resource().Attributes().Get(expected["resource-attr"].key)
 		assert.True(t, ok)
-		assert.Equal(t, expected["resource-attr"].val, val.AsString())
+		assert.Equal(t, expected["resource-attr"].val.AsString(), val.AsString())
 
 		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
 			// validate scope attributes
 			sm := rm.ScopeMetrics().At(j)
 			scopeVal, ok := sm.Scope().Attributes().Get(expected["scope-attr"].key)
 			assert.True(t, ok)
-			assert.Equal(t, expected["scope-attr"].val, scopeVal.AsString())
+			assert.Equal(t, expected["scope-attr"].val.AsString(), scopeVal.AsString())
 
 			for k := 0; k < sm.Metrics().Len(); k++ {
 				metric := sm.Metrics().At(k)
@@ -199,7 +247,10 @@ func validateMetricsAttrs(t *testing.T, expected map[string]pair, metrics pmetri
 						dp := gdp.At(i)
 						val, ok := dp.Attributes().Get(expected["gauge-attr"].key)
 						assert.True(t, ok)
-						assert.Equal(t, expected["gauge-attr"].val, val.AsString())
+						assert.Equal(t, expected["gauge-attr"].val.AsString(), val.AsString())
+						val2, ok := dp.Attributes().Get(expected["complex-metric-attr"].key)
+						assert.True(t, ok)
+						assert.Equal(t, expected["complex-metric-attr"].val.AsString(), val2.AsString())
 					}
 
 				case pmetric.MetricTypeSum:
@@ -208,7 +259,10 @@ func validateMetricsAttrs(t *testing.T, expected map[string]pair, metrics pmetri
 						dp := sdp.At(i)
 						val, ok := dp.Attributes().Get(expected["sum-attr"].key)
 						assert.True(t, ok)
-						assert.Equal(t, expected["sum-attr"].val, val.AsString())
+						assert.Equal(t, expected["sum-attr"].val.AsString(), val.AsString())
+						val2, ok := dp.Attributes().Get(expected["complex-metric-attr"].key)
+						assert.True(t, ok)
+						assert.Equal(t, expected["complex-metric-attr"].val.AsString(), val2.AsString())
 					}
 
 				case pmetric.MetricTypeHistogram:
@@ -217,7 +271,10 @@ func validateMetricsAttrs(t *testing.T, expected map[string]pair, metrics pmetri
 						dp := hdp.At(i)
 						val, ok := dp.Attributes().Get(expected["histogram-attr"].key)
 						assert.True(t, ok)
-						assert.Equal(t, expected["histogram-attr"].val, val.AsString())
+						assert.Equal(t, expected["histogram-attr"].val.AsString(), val.AsString())
+						val2, ok := dp.Attributes().Get(expected["complex-metric-attr"].key)
+						assert.True(t, ok)
+						assert.Equal(t, expected["complex-metric-attr"].val.AsString(), val2.AsString())
 					}
 
 				case pmetric.MetricTypeExponentialHistogram:
@@ -226,7 +283,10 @@ func validateMetricsAttrs(t *testing.T, expected map[string]pair, metrics pmetri
 						dp := ehdp.At(i)
 						val, ok := dp.Attributes().Get(expected["exp-histogram-attr"].key)
 						assert.True(t, ok)
-						assert.Equal(t, expected["exp-histogram-attr"].val, val.AsString())
+						assert.Equal(t, expected["exp-histogram-attr"].val.AsString(), val.AsString())
+						val2, ok := dp.Attributes().Get(expected["complex-metric-attr"].key)
+						assert.True(t, ok)
+						assert.Equal(t, expected["complex-metric-attr"].val.AsString(), val2.AsString())
 					}
 
 				case pmetric.MetricTypeSummary:
@@ -235,7 +295,10 @@ func validateMetricsAttrs(t *testing.T, expected map[string]pair, metrics pmetri
 						dp := smdp.At(i)
 						val, ok := dp.Attributes().Get(expected["summary-attr"].key)
 						assert.True(t, ok)
-						assert.Equal(t, expected["summary-attr"].val, val.AsString())
+						assert.Equal(t, expected["summary-attr"].val.AsString(), val.AsString())
+						val2, ok := dp.Attributes().Get(expected["complex-metric-attr"].key)
+						assert.True(t, ok)
+						assert.Equal(t, expected["complex-metric-attr"].val.AsString(), val2.AsString())
 					}
 				}
 			}
@@ -250,15 +313,18 @@ func TestProcessMetrics(t *testing.T) {
 		encrypt:    feistel.NewFPECipher(hash.SHA_256, "some-32-byte-long-key-to-be-safe", 128),
 		encryptAll: true,
 	}
+	cmVal := pcommon.NewValueMap()
+	newMap().CopyTo(cmVal.SetEmptyMap())
 
 	expected := map[string]pair{
-		"resource-attr":      cryptPair(processor, resAttrKey, resAttrVal),
-		"scope-attr":         cryptPair(processor, scopeAttrKey, scopeAttrVal),
-		"gauge-attr":         cryptPair(processor, "gauge-attr", gaugeAttrVal),
-		"sum-attr":           cryptPair(processor, "sum-attr", sumAttrVal),
-		"histogram-attr":     cryptPair(processor, "histogram-attr", histAttrVal),
-		"exp-histogram-attr": cryptPair(processor, "exp-histogram-attr", eHistAttrVal),
-		"summary-attr":       cryptPair(processor, "summary-attr", summaryAttrVal),
+		"resource-attr":       cryptPair(processor, resAttrKey, pcommon.NewValueStr(resAttrVal)),
+		"scope-attr":          cryptPair(processor, scopeAttrKey, pcommon.NewValueStr(scopeAttrVal)),
+		"gauge-attr":          cryptPair(processor, "gauge-attr", pcommon.NewValueStr(gaugeAttrVal)),
+		"sum-attr":            cryptPair(processor, "sum-attr", pcommon.NewValueStr(sumAttrVal)),
+		"histogram-attr":      cryptPair(processor, "histogram-attr", pcommon.NewValueStr(histAttrVal)),
+		"exp-histogram-attr":  cryptPair(processor, "exp-histogram-attr", pcommon.NewValueStr(eHistAttrVal)),
+		"summary-attr":        cryptPair(processor, "summary-attr", pcommon.NewValueStr(summaryAttrVal)),
+		"complex-metric-attr": cryptPair(processor, "complex-metric-attr", cmVal),
 	}
 
 	processedMetrics, err := processor.processMetrics(context.Background(), metrics)
@@ -277,6 +343,8 @@ func setupLogsWithAttrs() plog.Logs {
 
 	log := sl.LogRecords().AppendEmpty()
 	log.Attributes().PutStr("log-attr", logAttrVal)
+	mp := log.Attributes().PutEmptyMap("complex-log-attr")
+	newMap().CopyTo(mp)
 
 	return ld
 }
@@ -287,21 +355,25 @@ func validateLogsAttrs(t *testing.T, expected map[string]pair, logs plog.Logs) {
 		rl := logs.ResourceLogs().At(i)
 		val, ok := rl.Resource().Attributes().Get(expected["resource-attr"].key)
 		assert.True(t, ok)
-		assert.Equal(t, expected["resource-attr"].val, val.AsString())
+		assert.Equal(t, expected["resource-attr"].val.AsString(), val.AsString())
 
 		for j := 0; j < rl.ScopeLogs().Len(); j++ {
 			// validate scope attributes
 			sl := rl.ScopeLogs().At(j)
 			scopeVal, ok := sl.Scope().Attributes().Get(expected["scope-attr"].key)
 			assert.True(t, ok)
-			assert.Equal(t, expected["scope-attr"].val, scopeVal.AsString())
+			assert.Equal(t, expected["scope-attr"].val.AsString(), scopeVal.AsString())
 
 			for k := 0; k < sl.LogRecords().Len(); k++ {
 				// validate span attributes
 				log := sl.LogRecords().At(k)
 				val, ok := log.Attributes().Get(expected["log-attr"].key)
 				assert.True(t, ok)
-				assert.Equal(t, expected["log-attr"].val, val.AsString())
+				assert.Equal(t, expected["log-attr"].val.AsString(), val.AsString())
+
+				val2, ok := log.Attributes().Get(expected["complex-log-attr"].key)
+				assert.True(t, ok)
+				assert.Equal(t, expected["complex-log-attr"].val.AsString(), val2.AsString())
 			}
 		}
 	}
@@ -314,11 +386,14 @@ func TestProcessLogs(t *testing.T) {
 		encrypt:    feistel.NewFPECipher(hash.SHA_256, "some-32-byte-long-key-to-be-safe", 128),
 		encryptAll: true,
 	}
+	clVal := pcommon.NewValueMap()
+	newMap().CopyTo(clVal.SetEmptyMap())
 
 	expected := map[string]pair{
-		"resource-attr": cryptPair(processor, resAttrKey, resAttrVal),
-		"scope-attr":    cryptPair(processor, scopeAttrKey, scopeAttrVal),
-		"log-attr":      cryptPair(processor, "log-attr", logAttrVal),
+		"resource-attr":    cryptPair(processor, resAttrKey, pcommon.NewValueStr(resAttrVal)),
+		"scope-attr":       cryptPair(processor, scopeAttrKey, pcommon.NewValueStr(scopeAttrVal)),
+		"log-attr":         cryptPair(processor, "log-attr", pcommon.NewValueStr(logAttrVal)),
+		"complex-log-attr": cryptPair(processor, "complex-log-attr", clVal),
 	}
 
 	processedLogs, err := processor.processLogs(context.Background(), logs)


### PR DESCRIPTION
Resolves https://github.com/f5/otel-arrow-adapter/issues/192

This PR resolves an issue where only string attribute values were being obfuscated. This was an issue because strings can be nested in other value type like a slice or map.

(cc @jmacd)