### PR TITLE
Remove pointers in two of the optimizers

### DIFF
--- a/pkg/otel/common/arrow/analyzer.go
+++ b/pkg/otel/common/arrow/analyzer.go
@@ -642,7 +642,7 @@ func NewTimeIntervalStats() *TimeIntervalStats {
 	}
 }
 
-func (t *TimeIntervalStats) UpdateWithSpans(spans []*ptrace.Span) {
+func (t *TimeIntervalStats) UpdateWithSpans(spans []ptrace.Span) {
 	var prevStartTime time.Time
 	var prevEndTime time.Time
 

--- a/pkg/otel/metrics/arrow/optimizer.go
+++ b/pkg/otel/metrics/arrow/optimizer.go
@@ -47,7 +47,7 @@ type (
 		ScopeSchemaUrl string
 
 		// Metric section.
-		Metric *pmetric.Metric
+		Metric pmetric.Metric
 	}
 
 	MetricSorter interface {
@@ -95,7 +95,7 @@ func (t *MetricsOptimizer) Optimize(metrics pmetric.Metrics) *MetricsOptimized {
 					ScopeMetricsID:    scopeMetricsID,
 					Scope:             scope,
 					ScopeSchemaUrl:    scopeSchemaUrl,
-					Metric:            &metric,
+					Metric:            metric,
 				})
 			}
 		}

--- a/pkg/otel/traces/arrow/analyzer.go
+++ b/pkg/otel/traces/arrow/analyzer.go
@@ -147,7 +147,7 @@ func (r *ResourceSpansStats) UpdateWith(traces *TracesOptimized) {
 	scopeSpansCount := 0
 	spansPerScopeSpans := 0
 
-	var spans []*ptrace.Span
+	var spans []ptrace.Span
 
 	for _, span := range traces.Spans {
 		if prevResID != span.ResourceSpanID {

--- a/pkg/otel/traces/arrow/optimizer.go
+++ b/pkg/otel/traces/arrow/optimizer.go
@@ -50,7 +50,7 @@ type (
 		ScopeSchemaUrl string
 
 		// Span section.
-		Span *ptrace.Span
+		Span ptrace.Span
 	}
 
 	SpanSorter interface {
@@ -102,7 +102,7 @@ func (t *TracesOptimizer) Optimize(traces ptrace.Traces) *TracesOptimized {
 					ScopeSpanID:       scopeSpanId,
 					Scope:             scope,
 					ScopeSchemaUrl:    scopeSchemaUrl,
-					Span:              &span,
+					Span:              span,
 				})
 			}
 		}


### PR DESCRIPTION
Minor edit for consistency. The use of a pointer to `ptrace.Span` and `pmetric.Metric` raises flags about how these optimizers work, and it appears to be unnecessary. Note that these types are pointers under-the-hood anyway, and the optimizer was not using these as reference types.

Also note: the logs optimizer appears to work differently (slightly), so no change there. (Tangent: why does the logs optimizer use a `*ResScope` where the two others in-line the flattened thing?)