### PR TITLE
Reset the scope ID when resource ID changes

### DIFF
--- a/pkg/datagen/default.go
+++ b/pkg/datagen/default.go
@@ -95,6 +95,18 @@ func (te TestEntropy) NewStandardAttributes() pcommon.Map {
 	)
 }
 
+func (te TestEntropy) NewSingleResourceAttributes() []pcommon.Map {
+	return []pcommon.Map{
+		te.shuffleAttrs(
+			func(attrs Attrs) { attrs.PutStr("hostname", "host1.mydomain.com") },
+			func(attrs Attrs) { attrs.PutStr("ip", "192.168.0.1") },
+			func(attrs Attrs) { attrs.PutBool("up", true) },
+			func(attrs Attrs) { attrs.PutInt("status", 200) },
+			func(attrs Attrs) { attrs.PutDouble("version", 1.0) },
+		),
+	}
+}
+
 func (te TestEntropy) NewStandardResourceAttributes() []pcommon.Map {
 	return []pcommon.Map{
 		te.shuffleAttrs(
@@ -119,6 +131,14 @@ func (te TestEntropy) NewStandardResourceAttributes() []pcommon.Map {
 			func(attrs Attrs) { attrs.PutDouble("version", 1.5) },
 		),
 	}
+}
+
+func (te TestEntropy) NewSingleInstrumentationScopes() []pcommon.InstrumentationScope {
+	s1 := pcommon.NewInstrumentationScope()
+	s1.SetName("fake_generator")
+	s1.SetVersion("1.0.0")
+
+	return []pcommon.InstrumentationScope{s1}
 }
 
 func (te TestEntropy) NewStandardInstrumentationScopes() []pcommon.InstrumentationScope {

--- a/pkg/otel/logs/otlp/logs.go
+++ b/pkg/otel/logs/otlp/logs.go
@@ -89,6 +89,7 @@ func LogsFrom(record arrow.Record, relatedData *RelatedData) (plog.Logs, error) 
 			prevResID = int(resID)
 			resLogs = resLogsSlice.AppendEmpty()
 			scopeLogsSlice = resLogs.ScopeLogs()
+			prevScopeID = None
 			schemaUrl, err := otlp.UpdateResourceFromRecord(resLogs.Resource(), record, row, logRecordIDs.Resource, relatedData.ResAttrMapStore)
 			if err != nil {
 				return logs, werror.Wrap(err)

--- a/pkg/otel/metrics/otlp/metrics.go
+++ b/pkg/otel/metrics/otlp/metrics.go
@@ -77,6 +77,7 @@ func MetricsFrom(record arrow.Record, relatedData *RelatedData) (pmetric.Metrics
 			prevResID = int(resID)
 			resMetrics = resMetricsSlice.AppendEmpty()
 			scopeMetricsSlice = resMetrics.ScopeMetrics()
+			prevScopeID = None
 			schemaUrl, err := otlp.UpdateResourceFromRecord(resMetrics.Resource(), record, row, metricsIDs.Resource, relatedData.ResAttrMapStore)
 			if err != nil {
 				return metrics, werror.Wrap(err)

--- a/pkg/otel/traces/otlp/traces.go
+++ b/pkg/otel/traces/otlp/traces.go
@@ -95,6 +95,7 @@ func TracesFrom(record arrow.Record, relatedData *RelatedData) (ptrace.Traces, e
 			prevResID = int(resID)
 			resSpans = resSpansSlice.AppendEmpty()
 			scopeSpansSlice = resSpans.ScopeSpans()
+			prevScopeID = None
 			schemaUrl, err := otlp.UpdateResourceFromRecord(resSpans.Resource(), record, row, traceIDs.Resource, relatedData.ResAttrMapStore)
 			if err != nil {
 				return traces, werror.Wrap(err)


### PR DESCRIPTION
This corrects a problem discovered in an environment where Scope fields were unused, thus constant across Resources. In the fix here, which is also tested, the current scopeID value being used in the Producer would be incorrect since it matches the previous _from a different resource_.
