### PR TITLE
Delta-decode Resource and Scope IDs arriving in the Arrow consumer

### DIFF
--- a/pkg/datagen/default.go
+++ b/pkg/datagen/default.go
@@ -115,6 +115,7 @@ func (te TestEntropy) NewStandardResourceAttributes() []pcommon.Map {
 			func(attrs Attrs) { attrs.PutBool("up", true) },
 			func(attrs Attrs) { attrs.PutInt("status", 200) },
 			func(attrs Attrs) { attrs.PutDouble("version", 1.0) },
+			func(attrs Attrs) { attrs.PutStr("unique1", "uv1") },
 		),
 		te.shuffleAttrs(
 			func(attrs Attrs) { attrs.PutStr("hostname", "host2.mydomain.com") },
@@ -122,6 +123,7 @@ func (te TestEntropy) NewStandardResourceAttributes() []pcommon.Map {
 			func(attrs Attrs) { attrs.PutBool("up", true) },
 			func(attrs Attrs) { attrs.PutInt("status", 200) },
 			func(attrs Attrs) { attrs.PutDouble("version", 1.0) },
+			func(attrs Attrs) { attrs.PutStr("unique2", "uv2") },
 		),
 		te.shuffleAttrs(
 			func(attrs Attrs) { attrs.PutStr("hostname", "host3.mydomain.com") },
@@ -129,6 +131,7 @@ func (te TestEntropy) NewStandardResourceAttributes() []pcommon.Map {
 			func(attrs Attrs) { attrs.PutBool("up", false) },
 			func(attrs Attrs) { attrs.PutInt("status", 500) },
 			func(attrs Attrs) { attrs.PutDouble("version", 1.5) },
+			func(attrs Attrs) { attrs.PutStr("unique3", "uv3") },
 		),
 	}
 }

--- a/pkg/otel/logs/otlp/logs.go
+++ b/pkg/otel/logs/otlp/logs.go
@@ -79,9 +79,13 @@ func LogsFrom(record arrow.Record, relatedData *RelatedData) (plog.Logs, error) 
 	prevResID := None
 	prevScopeID := None
 
+	var resID uint16
+	var scopeID uint16
+
 	for row := 0; row < rows; row++ {
 		// Process resource logs, resource, schema url (resource)
-		resID, err := otlp.ResourceIDFromRecord(record, row, logRecordIDs.Resource)
+		resDeltaID, err := otlp.ResourceIDFromRecord(record, row, logRecordIDs.Resource)
+		resID += resDeltaID
 		if err != nil {
 			return logs, werror.Wrap(err)
 		}
@@ -98,7 +102,8 @@ func LogsFrom(record arrow.Record, relatedData *RelatedData) (plog.Logs, error) 
 		}
 
 		// Process scope logs, scope, schema url (scope)
-		scopeID, err := otlp.ScopeIDFromRecord(record, row, logRecordIDs.Scope)
+		scopeDeltaID, err := otlp.ScopeIDFromRecord(record, row, logRecordIDs.Scope)
+		scopeID += scopeDeltaID
 		if err != nil {
 			return logs, werror.Wrap(err)
 		}

--- a/pkg/otel/metrics/otlp/metrics.go
+++ b/pkg/otel/metrics/otlp/metrics.go
@@ -67,9 +67,13 @@ func MetricsFrom(record arrow.Record, relatedData *RelatedData) (pmetric.Metrics
 	prevResID := None
 	prevScopeID := None
 
+	var resID uint16
+	var scopeID uint16
+
 	for row := 0; row < rows; row++ {
 		// Process resource spans, resource, schema url (resource)
-		resID, err := otlp.ResourceIDFromRecord(record, row, metricsIDs.Resource)
+		resDeltaID, err := otlp.ResourceIDFromRecord(record, row, metricsIDs.Resource)
+		resID += resDeltaID
 		if err != nil {
 			return metrics, werror.Wrap(err)
 		}
@@ -86,7 +90,8 @@ func MetricsFrom(record arrow.Record, relatedData *RelatedData) (pmetric.Metrics
 		}
 
 		// Process scope spans, scope, schema url (scope)
-		scopeID, err := otlp.ScopeIDFromRecord(record, row, metricsIDs.Scope)
+		scopeDeltaID, err := otlp.ScopeIDFromRecord(record, row, metricsIDs.Scope)
+		scopeID += scopeDeltaID
 		if err != nil {
 			return metrics, werror.Wrap(err)
 		}

--- a/pkg/otel/traces/otlp/traces.go
+++ b/pkg/otel/traces/otlp/traces.go
@@ -85,17 +85,23 @@ func TracesFrom(record arrow.Record, relatedData *RelatedData) (ptrace.Traces, e
 	prevResID := None
 	prevScopeID := None
 
+	var resID uint16
+	var scopeID uint16
+
 	for row := 0; row < rows; row++ {
 		// Process resource spans, resource, schema url (resource)
-		resID, err := otlp.ResourceIDFromRecord(record, row, traceIDs.Resource)
+		resDeltaID, err := otlp.ResourceIDFromRecord(record, row, traceIDs.Resource)
+		resID += resDeltaID
 		if err != nil {
 			return traces, werror.Wrap(err)
 		}
+
 		if prevResID != int(resID) {
 			prevResID = int(resID)
 			resSpans = resSpansSlice.AppendEmpty()
 			scopeSpansSlice = resSpans.ScopeSpans()
 			prevScopeID = None
+
 			schemaUrl, err := otlp.UpdateResourceFromRecord(resSpans.Resource(), record, row, traceIDs.Resource, relatedData.ResAttrMapStore)
 			if err != nil {
 				return traces, werror.Wrap(err)
@@ -104,7 +110,8 @@ func TracesFrom(record arrow.Record, relatedData *RelatedData) (ptrace.Traces, e
 		}
 
 		// Process scope spans, scope, schema url (scope)
-		scopeID, err := otlp.ScopeIDFromRecord(record, row, traceIDs.Scope)
+		scopeDeltaID, err := otlp.ScopeIDFromRecord(record, row, traceIDs.Scope)
+		scopeID += scopeDeltaID
 		if err != nil {
 			return traces, werror.Wrap(err)
 		}


### PR DESCRIPTION
Fixes an error in decoding -- OTLP Resource and Scope IDs are delta-encoded by the producer and need to be delta-decoded in the consumer.

Adds unique-attribute keys to the `pkg/datagen/default.go` test resources and scopes so that consumer-producer tests will cover this scenario.